### PR TITLE
Publish to NuGet.org via trusted publishing instead of a stored API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,15 @@ on:
 permissions:
   contents: read
   packages: write
+  # Lets the job ask GitHub for an OIDC token, which NuGet.org exchanges for a short-lived API key.
+  # This is what removes the need for a long-lived NUGET_API_KEY secret.
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Must match the Environment field of the NuGet.org trusted publishing policy, or the token
+    # exchange is rejected.
     environment: nuget
 
     steps:
@@ -86,10 +91,27 @@ jobs:
           name: nupkgs-${{ steps.version.outputs.version }}
           path: ./nupkgs/*
 
+      # Trusted publishing: exchange GitHub's OIDC token for an API key that NuGet.org issues on the
+      # spot and expires in an hour. Nothing long-lived is stored in the repository, so there is no
+      # secret to leak or rotate — and the key's scope comes from the policy's package owner rather
+      # than from a glob pattern, so publishing a new package id needs no extra configuration.
+      #
+      # This step is deliberately here, immediately before the push, rather than at the top of the job:
+      # the key is valid for one hour and the build and test steps above take time.
+      #
+      # `user` is the nuget.org profile name, not an email address. It is a literal rather than a
+      # secret because it is public information — it appears on every package page — and a missing
+      # secret would break the release for no security benefit.
+      - name: Exchange OIDC token for a NuGet API key
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: i7aKeT
+
       - name: Publish to NuGet.org
         run: >
           dotnet nuget push "./nupkgs/*.nupkg"
-          --api-key ${{ secrets.NUGET_API_KEY }}
+          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
           --source https://api.nuget.org/v3/index.json
           --skip-duplicate
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,13 @@ The workflow refuses to publish if the tag is not valid SemVer or does not match
 `<Version>`, because a version pushed to NuGet.org can be unlisted but never replaced. It then builds,
 runs the full test suite, and pushes to NuGet.org and GitHub Packages.
 
+Authentication to NuGet.org uses **trusted publishing** rather than a stored API key: the job requests
+an OIDC token from GitHub, NuGet.org validates it against a policy and issues a key that expires in an
+hour. There is no long-lived secret in this repository to leak or rotate. The policy must match the
+workflow exactly — repository owner, repository name, workflow file `release.yml`, and environment
+`nuget` — so renaming this file or changing that environment breaks publishing until the policy is
+updated to match.
+
 Always release through the workflow. `dotnet pack` records the current branch in the nuspec's
 `<repository>` element, so a package built locally on a feature branch carries that branch name in its
 public metadata; packing from a tag ref records the tag.


### PR DESCRIPTION
## What does this change?

nuget.org now marks API keys as *strongly discouraged for automated publishing*. This switches `release.yml` to **trusted publishing**: the job requests an OIDC token from GitHub, NuGet.org validates it against a policy and returns an API key that expires in an hour. Nothing long-lived is stored in this repository.

Beyond removing a secret, this also removes the last real risk in the pending release. A trusted publishing policy is scoped to a package **owner**, not to a glob pattern — so publishing the new `SYT.NPKTools` id needs no key reissue and does not depend on the `SYT.` prefix being reserved, which it is not.

## Changes

- `permissions: id-token: write`, so the job can request the OIDC token.
- A `NuGet/login@v1` step placed **immediately before the push** rather than at the top of the job — the key is valid for one hour and the build and test steps above are not instant.
- The push takes its key from that step's output. `secrets.NUGET_API_KEY` is no longer referenced anywhere.

`user` is the nuget.org profile name, and it is a literal rather than a secret on purpose: it is public information that appears on every package page, and a missing secret would break the release for no security benefit.

GitHub Packages still authenticates with the built-in `GITHUB_TOKEN`, which was never a stored secret.

## Required configuration

The policy on nuget.org must match this workflow exactly, or the token exchange is rejected:

| Field | Value |
| --- | --- |
| Package Owner | `i7aKeT` |
| CI/CD Provider | GitHub Actions |
| Repository Owner | `i7aket` |
| Repository | `NPKTools` |
| Workflow File | `release.yml` (file name only, no path) |
| Environment | `nuget` |

Renaming this workflow file or changing its `environment:` breaks publishing until the policy is updated to match. The README now says so, since that coupling is invisible from the workflow itself.

## Known unknown

The NuGet documentation states that a policy "applies to all packages owned by the selected owner". `SYT.NPKTools` does not exist yet, so it is not yet owned — whether a trusted-publishing key may **create** a new package id is not stated explicitly.

If the release fails at the push step for that reason, the fallback is one line: publish the first version with a conventional API key, after which ownership exists and trusted publishing works normally for every later release.

## Type of change

- [x] Build / CI
- [x] Documentation

## Checklist

- [x] `dotnet build` is clean — unchanged by this PR
- [x] `dotnet test` passes — unchanged by this PR
- [ ] New or changed behaviour is covered by tests — not applicable; this is release plumbing, and the only real test is a release run
- [x] Public API changes carry XML documentation — none
- [x] `CHANGELOG.md` is updated for anything user-visible — not user-visible

The workflow YAML was parsed and its step order verified. It cannot be exercised further without an actual release run, which is the point of the change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFyDNzAAodoHV5rrc8X46v)_