### PR TITLE
Turn the solver into a calculator: water, ratios, custom salts, concentrates, units, EC (1.0.0-preview.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,34 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Together these close the standing complaint about comparable tools: that they compute a recipe but
   say nothing about whether it is a sensible one.
 
+- **A/B concentrates.** `mix.AsConcentrate(concentrateLiters)` splits a working-strength recipe into two
+  stock tanks and reports the dilution ratio and the dose per liter.
+
+  This is what makes a calculated recipe usable more than once. Weighing six salts every watering is
+  what stops people using one; mixing two tanks a month and dosing 10 ml of each is not. The whole
+  recipe's salt goes into the smaller volume, so a 100-liter recipe in a 1-liter tank is 1:100 —
+  concentrating changes how much water the salt goes into, never how much salt is needed, which is why
+  the finished solution still lands on the same target the optimizer solved for.
+
+  Two tanks rather than one for a chemical reason: calcium sulfate and the higher calcium phosphates are
+  barely soluble, so what stays dissolved at working strength falls out of solution at 100×. Each salt's
+  tank comes from its own `ConcentrateType`, which the preset catalogue already carries, so the split is
+  data rather than re-derived chemistry. A custom salt has none unless its author sets one, so a tank is
+  inferred from composition and the inference is reported — guessing silently is how someone's own
+  sulfate ends up beside calcium.
+
+  `HasPrecipitationRisk` flags calcium meeting sulfate or phosphate in one tank **from different salts**,
+  and is documented as a rule of thumb rather than a solubility calculation. A single salt carrying both
+  internally is deliberately not flagged: an audit of the catalogue found `Calcium Monobasic Phosphate`
+  (Ca 15.9%, P 24.6% in one compound), which the naive rule would have false-positived. A check that
+  fires on a legitimately soluble salt teaches users to ignore the check, so the guard is asserted in
+  both directions — the false positive must not fire, and an internally-mixed salt must not suppress a
+  genuine collision beside it.
+
+  `GramsPerLiter` per component is the figure to check against a salt's solubility. The reference
+  solubility values are not in the library yet, so nothing compares against it automatically; that is the
+  next step and is called out rather than implied.
+
 ## [1.0.0-preview.2] - 2026-08-01
 
 **A new package line.** `SYT.NPKTools` replaces the six `NPKTools.*` packages, which receive no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,32 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Together these close the standing complaint about comparable tools: that they compute a recipe but
   say nothing about whether it is a sensible one.
 
+- **EC estimation from the ions.** `ppm.EstimateConductivity()` predicts what a conductivity meter will
+  read, and `AsTdsPpm(scale)` converts that to the "ppm" a TDS meter shows.
+
+  Computed from each ion's molar conductivity rather than by scaling total dissolved solids by a fitted
+  factor, which is the distinction that makes it worth having: a mole of sulfate conducts more than twice
+  what a mole of dihydrogen phosphate does, so two solutions of identical ppm read differently and a single
+  factor cannot know which it was given. The per-ion shares come out of the same calculation, so a caller can
+  see that nitrate is usually about a third of the reading.
+
+  Checked against the certified KCl conductivity standards at 25 °C — the reference solutions meters
+  themselves are calibrated against. The estimate is **+0.1%** at 0.001 M and **+0.3%** at 0.01 M, which
+  bracket the ionic strength of a real feed, and −3.9% at 0.1 M, ten times stronger than anything anyone
+  grows in. A test asserts all three, including the last, so the boundary of usefulness is a fact in the
+  suite rather than a claim in a comment.
+
+  `IdealMicroSiemensPerCm` is the raw sum of limiting molar conductivities, exact at infinite dilution and
+  increasingly high above it as ions interfere with each other. `MicroSiemensPerCm` applies a Kohlrausch-form
+  correction, `Correction` exposes the factor used (≈0.91 for a normal feed) and `IonicStrength` the
+  exactly-computable quantity that sets it. The single coefficient in that correction is anchored on the
+  certified standards, not fitted to fertilizer recipes — which was the point of doing this ionically rather
+  than by regression.
+
+  Urea gives an EC of exactly zero while carrying a great deal of nitrogen, because an uncharged molecule
+  carries no current. Asserted as a test, because it is the reason EC is a poor proxy for feed strength
+  whenever urea is involved rather than an edge case to be smoothed over.
+
 - **mM and meq/L, and the charge balance.** `ppm.AsMillimolar()` converts a profile to millimoles per
   litre; `ppm.IonBalance()` expresses it as charge in milliequivalents and reports how the two sides
   compare.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   value objects rather than introducing sixteen more. It has no water volume, because a water analysis
   is a concentration and holds regardless of how much is used.
 
+- **Nutrient ratios and a per-fertilizer breakdown.** `ppm.Ratios()` returns the ratios a profile is
+  actually judged by — NO₃:NH₄, N:K, K:Ca, Ca:Mg, K:Mg, N:S, N:P — and `solution.Breakdown(calculator)`
+  attributes every element to the salt that supplied it.
+
+  Absolute ppm figures say how strong a solution is; the ratios say what it will do. NO₃:NH₄ is the one
+  worth watching most closely, because it predicts pH movement at the root rather than nutrition:
+  ammonium uptake acidifies the root zone, nitrate uptake alkalizes it.
+
+  A ratio whose denominator is zero is `null`, not zero and not infinity. A nitrate-only mix is the
+  everyday case and reporting "0" or "∞" for its NO₃:NH₄ would be actively misleading.
+
+  The breakdown answers what a bare recipe cannot: which salt is responsible for the sulfur nobody
+  asked for. Every salt brings a counter-ion along with the nutrient you wanted, so an unrequested
+  element is rarely a mistake — it is the price of the element next to it, and seeing which salt carries
+  it is what makes a recipe adjustable. Contributions are measured through the same calculator as the
+  whole mix, so the parts cannot drift from the total; a test asserts they sum.
+
+  Together these close the standing complaint about comparable tools: that they compute a recipe but
+  say nothing about whether it is a sensible one.
+
 ## [1.0.0-preview.2] - 2026-08-01
 
 **A new package line.** `SYT.NPKTools` replaces the six `NPKTools.*` packages, which receive no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,9 +130,35 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   both directions — the false positive must not fire, and an internally-mixed salt must not suppress a
   genuine collision beside it.
 
-  `GramsPerLiter` per component is the figure to check against a salt's solubility. The reference
-  solubility values are not in the library yet, so nothing compares against it automatically; that is the
-  next step and is called out rather than implied.
+- **Concentrates are checked against solubility.** `SolubilityTable` holds how much of each salt a litre of
+  water takes at 20 °C, and `AsConcentrate` now reports whether the tanks can physically be mixed.
+
+  Two checks, catching different mistakes. A single salt past its own limit is certain — arithmetic against
+  a published figure — and monocalcium phosphate at 18 g/L is what binds first in practice, against
+  potassium nitrate's 316 and calcium nitrate's 1290. The second is the tank as a whole:
+  `ConcentrateTank.SaturationFraction` adds each salt's share of its own limit, and above 1 the tank cannot
+  dissolve. That one was added after measurement, not by design: a 1:500 concentrate reaching 610 g/L in one
+  tank passed the per-salt check with every salt comfortably inside its own limit, which is too permissive
+  to be useful. Salts in a tank compete for the same water. The sum of fractions is the standard first-order
+  screen — exact for a single salt, slightly optimistic for a mixture, since salts sharing an ion crowd each
+  other out more than the sum suggests.
+
+  `ConcentratePlan.MaxDilutionRatio` answers the question the warning raises: a 1:1000 concentrate that
+  cannot dissolve may be fine at 1:600.
+
+  **A salt with no published figure is reported rather than assumed safe.** The table covers 21 of the
+  catalogue's 34 salts; the rest — calcium chloride hexahydrate, urea phosphate, the EDTA chelates, sodium
+  silicate and selenate, the nitrate micro salts — carry no entry, because the figures in circulation for
+  them disagree by more than the check would be worth. A chelate's solubility depends on the formulation, a
+  deliquescent hydrate's on which hydrate it is. Guessing would be worse than declining: a wrong limit
+  either blocks a tank that would have mixed or passes one that will not. Those salts come back in
+  `ConcentratePlan.UnknownSolubility`, `SaturationFraction` is null rather than a partial sum, and no
+  ceiling is computed — the missing salt could be the one that binds. `SolubilityTable.With` takes a figure
+  off a bag label for a salt of your own.
+
+  A test asserts that every name in the table resolves to a real catalogue salt. It exists because the
+  first version of the table misspelled five micro-salt names, and a name that matches nothing fails
+  silently: the salt reports as unchecked and the check appears to work.
 
 ## [1.0.0-preview.2] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,34 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Together these close the standing complaint about comparable tools: that they compute a recipe but
   say nothing about whether it is a sensible one.
 
+- **mM and meq/L, and the charge balance.** `ppm.AsMillimolar()` converts a profile to millimoles per
+  litre; `ppm.IonBalance()` expresses it as charge in milliequivalents and reports how the two sides
+  compare.
+
+  Ppm is a mass unit and so flatters the light elements: 40 ppm of calcium and 40 ppm of magnesium are
+  1.00 mM and 1.65 mM. Every published formulation — Steiner, Hoagland, the Dutch advisory tables — is
+  stated in mM, so working from a paper recipe meant converting sixteen numbers by hand.
+
+  The charge balance turned out to be more interesting than expected, and the first version of this entry
+  described it wrongly as an error check. It is not: every salt is electrically neutral, so a recipe of
+  nothing but salts balances exactly, and where it does not the gap is the acid or base the recipe itself
+  contributes. `AcidEquivalents` reports that in meq/L of H⁺ — positive pulls pH down, negative pushes it
+  up. Measured across the catalogue, fourteen of the seventeen macro salts come out at exactly zero;
+  phosphoric acid at +1 proton per phosphorus, urea phosphate likewise, and dipotassium phosphate at −1,
+  which are exactly the three salts with acid-base character. So the figure says whether a recipe needs
+  more or less pH-down than the water alone would suggest.
+
+  Micronutrients are excluded from the charge figures deliberately. Iron may be Fe²⁺ or Fe³⁺ and in
+  chelated form the complex is an anion rather than a cation, so any charge for it is a guess, and at under
+  5 ppm in total they would move the balance by less than 0.1 meq/L against a typical 25–30 — uncertainty
+  added to a figure whose worth is that it is exact. Boron and silicon are excluded for a firmer reason: as
+  boric and silicic acid they are undissociated at nutrient-solution pH. Urea contributes nitrogen in mM
+  and nothing in meq, being a neutral molecule.
+
+  Phosphorus is counted as H₂PO₄⁻ at one charge, the dominant species between pH 5.5 and 6.5. Above pH 7.2
+  half of it is HPO₄²⁻; the library does not model pH, so the assumption is documented rather than
+  computed. It is also what makes the acid-base figures come out in whole protons.
+
 - **Bundles are generated from your own salts.** `NpkTools.CreateOptimizationService(shelf)` takes a list
   of salts and searches it the way the service searches the preset catalogue.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Together these close the standing complaint about comparable tools: that they compute a recipe but
   say nothing about whether it is a sensible one.
 
+- **A source-water analysis reads its own alkalinity.** `water.AsPpm()` runs a `WaterProfile` through the
+  solution analyses, and `water.EstimatedAlkalinity()` reports the bicarbonate its cation-anion gap implies.
+
+  This fell out of the charge balance rather than being designed. A finished recipe's cations equal its
+  anions; a water analysis's do not, and that is not an error in the analysis — bicarbonate is what balances
+  real water, it is not a plant nutrient, and so it has nowhere to be entered. The gap left over is a
+  measurement of it. On an ordinary municipal analysis (Ca 45, Mg 12, S 18, Na 20, Cl 25) the surplus is
+  2.27 meq/L, which is 139 ppm of HCO₃⁻ or 114 as CaCO₃ — and also the acid needed per litre to neutralise
+  the water, which is the number that decides whether hard water pushes root-zone pH up all season.
+
+  The water's own EC comes with it, and is the quickest check that an analysis was typed in correctly:
+  compare it against the meter reading the grower already has. The same tap water above reads 358 µS/cm.
+
+  An estimate from what the analysis contains rather than a substitute for a measured alkalinity figure — it
+  cannot distinguish bicarbonate from carbonate or from an ion nobody entered, and it clamps at zero, since
+  negative alkalinity is not a thing.
+
 - **EC estimation from the ions.** `ppm.EstimateConductivity()` predicts what a conductivity meter will
   read, and `AsTdsPpm(scale)` converts that to the "ppm" a TDS meter shows.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Source water is deducted from the target.** `WaterProfile` describes what the tap or well water
+  already contains, and `target.AdjustFor(water)` returns the target the fertilizers actually have to
+  meet.
+
+  This is a correctness fix disguised as a feature. Whatever the water carries is added on top of
+  everything the fertilizers contribute, so on an ordinary municipal analysis — Ca 45, Mg 15, S 20 — a
+  mix calculated against the raw target overshoots calcium by **45%**, magnesium by 30% and sulfur by
+  33%. Deducting first lands every element on target exactly. It is also the feature every serious
+  competitor has and this library did not.
+
+  The deduction happens ahead of the optimizer rather than inside it: the result is an ordinary
+  `PpmTarget`, so the solver, mapper and bundles are untouched, and the arithmetic stays inspectable.
+  `WaterProfile.Pure` is the all-zero profile for reverse osmosis and leaves a target unchanged, which
+  is asserted as a regression guard for callers who do not use the feature.
+
+  Where the water already oversupplies an element, that element is clamped to zero and reported in
+  `WaterAdjustedTarget.Excesses` rather than silently truncated. Fertilizer only adds, so no mix can
+  bring it down — the remedies are to raise the target or dilute the water, both outside the
+  calculation. Hard water against a low calcium target is the everyday case.
+
+  `WaterProfile` carries all 16 elements, symmetric with `PpmTarget`, and reuses the existing `*Ppm`
+  value objects rather than introducing sixteen more. It has no water volume, because a water analysis
+  is a concentration and holds regardless of how much is used.
+
 ## [1.0.0-preview.2] - 2026-08-01
 
 **A new package line.** `SYT.NPKTools` replaces the six `NPKTools.*` packages, which receive no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,43 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   first version of the table misspelled five micro-salt names, and a name that matches nothing fails
   silently: the salt reports as unchecked and the check appears to work.
 
+  **The figures were then reviewed against published values, and three were wrong.** The other eighteen
+  were confirmed, several to the digit — magnesium sulfate heptahydrate 710, MKP 226, dipotassium phosphate
+  1490, potassium sulfate 111, boric acid 49, iron(II) sulfate heptahydrate 256, copper sulfate
+  pentahydrate 320, sodium molybdate dihydrate 840, calcium nitrate tetrahydrate 1290.
+
+  | salt | was | now | why it was wrong |
+  | --- | --- | --- | --- |
+  | Ammonium nitrate | 1500 | **1920** | the 10 °C figure had been used instead of the 20 °C one |
+  | Magnesium nitrate hexahydrate | 1250 | **420** | the anhydrous salt's figure under the hydrate's name |
+  | Zinc sulfate monohydrate | 600 | **350** | same, and the heptahydrate's 965 was in circulation too |
+
+  The last two overstated the limit, which is the direction that matters: the check passed tanks that cannot
+  dissolve. A magnesium-nitrate-fed recipe at 1:100 needs 528 g/L where 420 is the limit, and the old figure
+  waved it through; the computed ceiling for that mix moves from 1:237 to 1:80.
+
+  The cause in both cases was the basis, not the arithmetic. Handbooks report a hydrate's solubility two
+  ways — as the hydrate, or as the anhydrous salt it contains — and the two differ by a factor of two for
+  magnesium sulfate. The table now documents its basis explicitly (grams of the salt *as the catalogue names
+  it*, water of crystallisation included, per litre of water at 20 °C) and carries each published
+  "g per 100 mL" entry as a trailing comment, so any value can be re-checked without unit arithmetic.
+
+  A test now pins **all** 21 figures rather than the five lowest. The earlier test pinned only the low ones,
+  reasoning that those bind first — and none of the three wrong values was among them, so the suite passed
+  while the table was wrong. The table's size is pinned too, so a new entry cannot be added unasserted.
+
+- **The physical constants are pinned against published values.** The atomic weights, ionic charges and molar
+  conductivities were checked and are now asserted through the conversions that use them, since they are
+  internal.
+
+  Nothing else in the suite would notice these being wrong: a mistaken atomic weight shifts every mM and meq
+  figure by a few percent and no test fails, and a mistaken molar conductivity moves EC in a way that reads
+  as ordinary model error. All sixteen atomic weights match the IUPAC standard values, and the ten
+  conductivities match the CRC infinite-dilution table cross-checked against a second compilation. H₂PO₄⁻ is
+  the one with real spread in the literature — 31.8 to 36 depending on source — which moves total EC by under
+  half a percent, since phosphate is about 2% of a feed's conductivity. A test also asserts the divalent
+  values are per mole of ion rather than per equivalent, the distinction that would otherwise halve them.
+
 ## [1.0.0-preview.2] - 2026-08-01
 
 **A new package line.** `SYT.NPKTools` replaces the six `NPKTools.*` packages, which receive no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   cannot distinguish bicarbonate from carbonate or from an ion nobody entered, and it clamps at zero, since
   negative alkalinity is not a thing.
 
+- **The reservoir's profile, water included.** `salts.Plus(water)` composes a mix with its source water, and
+  `EstimateConductivity` takes an optional bicarbonate term.
+
+  Every analysis in this library describes the profile it is handed, so handing it a mix's own ppm silently
+  answers a different question — what the salts would read in pure water. On a moderately hard supply the
+  reservoir reads 2.21 mS/cm where the salts alone give 1.81, a 22% gap: two-thirds of it the water's
+  nutrients, the rest its bicarbonate. Anyone comparing a meter against the salts-only figure would conclude
+  their feed was weak and push it harder.
+
+  `Plus` exists because composing the two by hand is error-prone in a specific way — it is a nutrient at a
+  time, and forgetting that nitrogen has three forms drops the ammonium silently. That mistake was made
+  while writing the documentation for the previous entry, so there is now a method and a test for it.
+
+  Bicarbonate is an argument to `EstimateConductivity` rather than a field on `Ppm`, because HCO₃⁻ is not a
+  plant nutrient and belongs in no nutrient profile — but it conducts, and in tap water it carries most of
+  the negative charge. `water.EstimateConductivity()` fills it in from `EstimatedAlkalinity()`, which is
+  defensible only for a water analysis: there the cation surplus is the alkalinity, whereas in a recipe the
+  same gap is the salts' acid-base character. Without it the water alone reads 358 µS/cm against the ~454 a
+  meter shows — a quarter low. Acidifying the reservoir removes some of that bicarbonate and some of the EC;
+  that is not modelled.
+
 - **EC estimation from the ions.** `ppm.EstimateConductivity()` predicts what a conductivity meter will
   read, and `AsTdsPpm(scale)` converts that to the "ppm" a TDS meter shows.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,33 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Together these close the standing complaint about comparable tools: that they compute a recipe but
   say nothing about whether it is a sensible one.
 
+- **Bundles are generated from your own salts.** `NpkTools.CreateOptimizationService(shelf)` takes a list
+  of salts and searches it the way the service searches the preset catalogue.
+
+  This is the answer to "I want to use what I have". The catalogue offers eighteen macro bundles and so a
+  dozen recipes to compare; a custom shelf used to be one bundle and therefore one recipe. Everything
+  downstream is unchanged, because `CustomFertilizerBundleRepository` is an ordinary
+  `IFertilizerBundleRepository` — the same solver, the same ppm calculator, the same concentrate split.
+
+  The generation rule is hold-one-out: the first bundle holds every salt, and each of the others leaves
+  out exactly one. It was chosen by measurement, not taste. Counting distinct recipes returned across
+  three macro targets: one-source-per-element cross product scored 5, the hand-written catalogue 19,
+  hold-one-out **21**, and holding out pairs and triples as well also 21. Depth beyond one buys nothing —
+  a smaller subset either reproduces a recipe already found or solves nothing — so it is not implemented.
+
+  The reason building bundles up scores so badly is worth recording: six simultaneous element targets need
+  at least six salts to satisfy at non-negative weights, and a bundle assembled as one source per element
+  rarely has six once overlapping salts collapse. The first version of this feature did exactly that and
+  scored 5 against the catalogue's 19; it was replaced rather than tuned.
+
+  `GeneratedBundles` reports what generation could not do: `UncoveredElements` names elements no supplied
+  salt contains, and `CustomFertilizerBundleRepository.UnusableSalts` names salts carrying nothing any
+  target can ask for. Without the first, a missing magnesium source appears as "no solutions" and sends
+  someone hunting through their shelf for a mistake that is not there.
+
+  Macro and micro split as the catalogue splits them — any micronutrient makes a salt a micro salt, so
+  iron sulfate's incidental sulfur cannot be recruited to meet a sulfur target.
+
 - **A/B concentrates.** `mix.AsConcentrate(concentrateLiters)` splits a working-strength recipe into two
   stock tanks and reports the dilution ratio and the dose per liter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,17 @@
 All notable changes to this project are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0-preview.3] - 2026-08-01
+
+**The calculator, not just the solver.** Everything below turns a recipe into something a grower can act on:
+the source water is accounted for, the mix can be judged rather than only computed, a person's own salts are
+searched like the catalogue, and the result can be stored as an A/B concentrate that is checked for whether it
+will physically dissolve.
+
+Three of the numeric claims in this release are checkable against external authorities, and the tests check
+them: the EC model against the certified KCl conductivity standards, the solubility figures against published
+handbook values, and the physical constants against the IUPAC and CRC tables. Where a figure could not be
+sourced with confidence it was left out and is reported as unchecked rather than assumed safe.
 
 ### Added
 
@@ -260,6 +270,33 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the one with real spread in the literature — 31.8 to 36 depending on source — which moves total EC by under
   half a percent, since phosphate is about 2% of a feed's conductivity. A test also asserts the divalent
   values are per mole of ion rather than per equivalent, the distinction that would otherwise halve them.
+
+### Found by pre-release review
+
+An adversarial review of this release, run before publishing, turned up three defects in the new code. All
+three were reproduced, fixed and pinned by regression test. The existing suite had passed over all of them.
+
+- **`MaxDilutionRatio` discarded the limits it knew when a tank held one salt it did not.** A tank with a
+  custom salt beside an over-limit MKP reported no constraint of its own, so the ceiling came from the other
+  tank entirely: 1:1290 for a tank whose MKP stops dissolving near 1:45, a factor of 28 in the direction that
+  ruins a batch. The ceiling is now computed from the salts with known limits and ignores the rest, which
+  loosens the bound but never discards a constraint. Salts left out of it are named in `UnknownSolubility`, so
+  a non-empty list means the ceiling is optimistic. This is the one place the reasoning differs from
+  `SaturationFraction`, which stays null on an unknown because a partial sum there would read as a verdict on
+  the tank.
+
+- **The conductivity estimate went non-monotonic and reached zero.** The Kohlrausch correction was applied
+  unbounded, so it turned the estimate downwards past an ionic strength of about 1.1 and hit exactly zero
+  near 3.3 — a saturated solution reported no conductivity at all, silently, with no NaN or exception. That
+  range is reachable through the library's own flagship path: a working feed in a 1:100 concentrate tank sits
+  near 2.5. The correction is now frozen at the top of the range it was anchored on, which keeps the figure
+  monotonic and non-zero, and the new `IsWithinValidatedRange` says when it should be read as an ordering
+  rather than a measurement. Nothing inside the anchored range moved — the KCl standards still come out at
+  +0.1%, +0.3% and −3.9%.
+
+- **A stale figure in the shipped XML documentation.** The remark on `WaterProfile.EstimateConductivity`
+  quoted 456 µS/cm where the code, the README and the tests all say 454, left over from an earlier
+  coefficient. It would have reached users through IntelliSense.
 
 ## [1.0.0-preview.2] - 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,16 @@ WaterProfile tap = new WaterProfileBuilder()
 double meq = tap.EstimatedAlkalinity();                       // 2.27 meq/L
 Console.WriteLine($"{meq * 61:F0} ppm HCO3-");                // 139
 Console.WriteLine($"{meq * 50:F0} ppm as CaCO3");             // 114 — how water reports usually state it
-Console.WriteLine(tap.AsPpm().EstimateConductivity()
-    .MicroSiemensPerCm.ToString("F0"));                       // 358 µS/cm
+
+// the water's own EC, bicarbonate included
+Console.WriteLine(tap.EstimateConductivity()
+    .MicroSiemensPerCm.ToString("F0"));                       // 454 µS/cm
 ```
+
+Use `water.EstimateConductivity()` rather than `water.AsPpm().EstimateConductivity()` — the second leaves
+bicarbonate out and reads 358 against the 454 a meter would show. Inferring the bicarbonate is only
+defensible here: in a water analysis the cation surplus *is* the alkalinity, whereas in a recipe the same
+gap is the salts' own acid-base character and has nothing to do with bicarbonate.
 
 That is also the acid needed per litre to neutralise the water, which is why it is worth surfacing: hard
 water pushes root-zone pH up all season if it is not accounted for. And the water's own EC is the quickest
@@ -227,6 +234,32 @@ ConductivityEstimate ec = ppm.EstimateConductivity();
 Console.WriteLine($"{ec.MilliSiemensPerCm:F2} mS/cm");   // 2.04
 Console.WriteLine($"{ec.AsTdsPpm(500):F0} ppm TDS");     // 1020 on a 500-scale meter
 ```
+
+**Include the source water, or the number is not the reservoir's.** Every analysis here describes the
+profile it is handed, so a mix's own ppm answers a question nobody asked — what the salts would read in
+pure water. On a hard supply that is a fifth low:
+
+```csharp
+Ppm salts = calculator.CalculatePpm(mix, mix.WaterLiters);
+
+// what is actually in the reservoir
+Ppm tank = salts.Plus(tap);
+ConductivityEstimate ec = tank.EstimateConductivity(tap.EstimatedAlkalinity());
+```
+
+| what you measure | mS/cm |
+| --- | --- |
+| the salts alone | 1.81 |
+| salts + the water's nutrients | 2.13 |
+| **+ the water's bicarbonate — what the meter shows** | **2.21** |
+
+`Plus` exists because composing the two by hand is easy to get wrong: it is a nutrient at a time, and
+forgetting that nitrogen has three forms drops the ammonium silently. That mistake was made while writing
+this documentation, which is why there is now a method and a test for it.
+
+The bicarbonate is a separate argument rather than part of the profile because HCO₃⁻ is not a plant
+nutrient — it belongs in no `Ppm`. It still conducts, and in tap water it carries most of the negative
+charge. Acidifying the reservoir removes some of it, and with it some of the EC; that is not modelled.
 
 It is computed the way conductivity works — each ion's own molar conductivity times how much of it there
 is — not by scaling total dissolved solids by a fitted factor. That distinction is not academic: a mole of

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the browser under WebAssembly.
 dotnet add package SYT.NPKTools
 ```
 
-> **This is `1.0.0-preview.2`.** It supersedes the `NPKTools.*` packages, which are no longer
+> **This is `1.0.0-preview.3`.** It supersedes the `NPKTools.*` packages, which are no longer
 > updated. If you are coming from those, see [Migrating from NPKTools 1.x](#migrating-from-npktools-1x).
 
 ## Quick start
@@ -297,9 +297,14 @@ water, and increasingly high above it because ions interfere with each other as 
 quantity that decides it. Nothing is hidden behind a magic number: the one coefficient in the model comes
 from those certified standards, not from fitting to fertilizer recipes.
 
-Expect a few percent, not a meter replacement. The remaining error is not all the model's — the source
-water's bicarbonate conducts and is not modelled, meter calibration drifts, and temperature compensation
-is itself approximate.
+Expect a few percent, not a meter replacement. The remaining error is not all the model's — meter
+calibration drifts and temperature compensation is itself approximate.
+
+**Check `IsWithinValidatedRange` if you might be measuring a concentrate.** The correction is anchored on
+reference solutions up to an ionic strength of 0.1 M; a working feed sits near 0.025, but the same feed in a
+1:100 tank is near 2.5 — an order of magnitude past anything the model was checked against. The estimate
+stays monotonic there, so more salt always reads as more conductivity, but it runs increasingly high and
+should be treated as an ordering rather than a measurement.
 
 **Urea reads as pure water.** 150 ppm of nitrogen as urea gives an EC of exactly 0, because an uncharged
 molecule carries no current. That is not a bug to work around; it is the reason EC is a poor proxy for feed
@@ -445,7 +450,9 @@ Two checks run, and they catch different mistakes:
   sum suggests.
 
 `MaxDilutionRatio` is the answer to "then how strong *can* I make it": a 1:1000 concentrate that cannot
-dissolve may be fine at 1:600.
+dissolve may be fine at 1:600. Salts listed in `UnknownSolubility` are not part of that bound — there is no
+figure to bound them with — so when that list is non-empty the ceiling is an optimistic one and the two must
+be read together.
 
 **On the basis of these figures**, because it is where they go wrong. Each is grams of the salt *as the
 catalogue names it* — water of crystallisation included — per litre of water at 20 °C, and the source
@@ -696,8 +703,8 @@ Publishing is triggered by a version tag, not by pushes to `main`. Bump `<Versio
 `src/Directory.Build.props`, commit it, then tag:
 
 ```bash
-git tag v1.0.0-preview.2
-git push origin v1.0.0-preview.2
+git tag v1.0.0-preview.3
+git push origin v1.0.0-preview.3
 ```
 
 The workflow refuses to publish if the tag is not valid SemVer or does not match the committed

--- a/README.md
+++ b/README.md
@@ -307,6 +307,57 @@ both internally is not flagged — monocalcium phosphate is a soluble compound, 
 happen to be adjacent, and a check that fired on it would teach you to ignore the check. Predicting
 actual precipitation needs solubility products, pH and temperature, none of which this library models.
 
+### Will it actually dissolve?
+
+The other way a concentrate fails is simpler: there is more salt than the water can hold.
+
+```csharp
+ConcentratePlan plan = mix.AsConcentrate(concentrateLiters: 1);
+
+if (plan.ExceedsSolubility)
+{
+    Console.WriteLine($"too strong — go no further than 1:{plan.MaxDilutionRatio:F0}");
+}
+```
+
+Two checks run, and they catch different mistakes:
+
+- **One salt past its own limit.** Certain — arithmetic against a published figure. Monocalcium phosphate
+  at 18 g/L is the one that bites first in practice, against potassium nitrate's 316 and calcium nitrate's
+  1290.
+- **The tank saturated as a whole.** `SaturationFraction` adds each salt's share of its own limit; above 1
+  the tank cannot dissolve. Without this, four salts each at 40% of their limit pass individually and fail
+  in the bucket, because they compete for the same water. It is a first-order screen — exact for a single
+  salt, slightly optimistic for a mixture, since salts sharing an ion crowd each other out more than the
+  sum suggests.
+
+`MaxDilutionRatio` is the answer to "then how strong *can* I make it": a 1:1000 concentrate that cannot
+dissolve may be fine at 1:600.
+
+**A salt with no published figure is reported, not assumed.** `SolubilityTable.Default` covers 21 of the
+catalogue's 34 salts. The rest — calcium chloride hexahydrate, urea phosphate, the EDTA chelates, sodium
+silicate and selenate, the nitrate micro salts — carry no entry, because the figures in circulation for
+them disagree by more than the check would be worth. A chelate's solubility depends on the formulation; a
+deliquescent hydrate's on which hydrate it actually is. Guessing would be worse than declining: a wrong
+limit either blocks a tank that would have mixed or passes one that will not.
+
+```csharp
+foreach (string salt in plan.UnknownSolubility)
+{
+    Console.WriteLine($"{salt}: no figure, nothing checked");
+}
+```
+
+For a salt of your own, take the figure off the bag:
+
+```csharp
+SolubilityTable table = SolubilityTable.Default.With("My Own Salt", gramsPerLitreAt20C: 320);
+ConcentratePlan plan = mix.AsConcentrate(concentrateLiters: 1, table);
+```
+
+The figures are for 20 °C in pure water. Solubility rises steeply with temperature, so a cold garage is
+the pessimistic case and a warm room the forgiving one.
+
 ## Dependency injection
 
 Two ways, both supported. Pick by whether you would rather have one line or zero dependencies.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,57 @@ Every salt brings a counter-ion along with the nutrient you wanted, so an unrequ
 a mistake — it is the price of the element next to it. Contributions are measured through the same
 calculator as the whole mix, so the parts always sum to the total.
 
+## mM and meq/L, and what the charge balance tells you
+
+Ppm is a mass unit, so it flatters the light elements. 40 ppm of calcium and 40 ppm of magnesium look
+alike and are not: 1.00 mM against 1.65 mM, two-thirds again as many magnesium ions. Every published
+formulation — Steiner, Hoagland, the Dutch advisory tables — is stated in mM for that reason, so working
+from a paper recipe means converting.
+
+```csharp
+MolarProfile mM = ppm.AsMillimolar();     // all 16 elements, plus the three nitrogen forms
+IonBalance ions = ppm.IonBalance();       // charge, in milliequivalents per litre
+```
+
+```
+element    ppm      mM     meq/L
+NO3-N    150.0   10.71   10.71
+P         50.0    1.61    1.61
+K        210.0    5.37    5.37
+Ca       160.0    3.99    7.98
+Mg        50.0    2.06    4.11
+S         65.0    2.03    4.05
+
+cations 17.47  anions 16.38  total 33.85 meq/L
+```
+
+**The gap between the two sides is not an error.** Every salt is electrically neutral, so a recipe of
+nothing but salts balances exactly — and where it does not, the gap is the acid or base the recipe itself
+contributes. `AcidEquivalents` is that number, in meq/L of H⁺:
+
+| salt | AcidEquivalents | why |
+| --- | --- | --- |
+| monopotassium phosphate | 0.00 | K⁺ against H₂PO₄⁻, one charge each |
+| phosphoric acid | **+10.20** | supplies H₂PO₄⁻ with a proton, not a metal |
+| dipotassium phosphate | **−5.74** | two K⁺ against HPO₄²⁻, which takes up a proton at working pH |
+
+Positive means the recipe pulls pH down by itself, so less pH-down is needed than the water's alkalinity
+alone suggests. Negative means it pushes pH up. Across the built-in catalogue, fourteen of the seventeen
+macro salts come out at exactly zero; the three that do not are precisely the three with acid-base
+character.
+
+Micronutrients are left out of the charge figures on purpose. Iron may be Fe²⁺ or Fe³⁺ and in chelated
+form the complex is an anion rather than a cation, so a charge for it would be a guess — and at under
+5 ppm in total they would move the balance by less than 0.1 meq/L against a typical 25–30. Boron and
+silicon are excluded for a firmer reason: as boric and silicic acid they are undissociated at
+nutrient-solution pH and carry no charge at all. Urea likewise contributes nitrogen in mM and nothing in
+meq, because it is a neutral molecule.
+
+Phosphorus is counted as H₂PO₄⁻ at one charge, the dominant species between pH 5.5 and 6.5 where these
+solutions are run. Above pH 7.2 half of it is HPO₄²⁻. This library does not model pH, so the assumption
+is stated rather than computed — and it is what makes the acid-base figures above come out in whole
+protons.
+
 ## Use the salts you already have
 
 The preset catalogue offers eighteen macro bundles and therefore a dozen recipes to compare. Someone
@@ -323,7 +374,7 @@ runs.
 | --- | --- |
 | `SYT.NPKTools` | `Solution`, `Solutions`, `FertilizerSolutions`, the preset catalogue and the `NpkTools` factory |
 | `SYT.NPKTools.Fertilizers` | `Fertilizer`, its nutrient value objects and builders |
-| `SYT.NPKTools.Nutrients` | `Ppm`, `PpmTarget`, `WaterProfile`, `NutrientRatios`, the ppm calculator and the target parser |
+| `SYT.NPKTools.Nutrients` | `Ppm`, `PpmTarget`, `WaterProfile`, `NutrientRatios`, `MolarProfile`, `IonBalance`, the ppm calculator and the target parser |
 | `SYT.NPKTools.Concentrates` | `ConcentratePlan` and the A/B tank split |
 | `SYT.NPKTools.Optimization` | The linear program, the solver, the mapper and the settings |
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,29 @@ alone suggests. Negative means it pushes pH up. Across the built-in catalogue, f
 macro salts come out at exactly zero; the three that do not are precisely the three with acid-base
 character.
 
+### Your water's alkalinity, for free
+
+`water.AsPpm()` runs a source-water analysis through the same tools, and there the charge balance measures
+something a recipe's cannot. Real water is electrically neutral, but the ion that usually balances it —
+bicarbonate — is not one of the sixteen nutrients and so has nowhere to be entered. The cation surplus left
+over is therefore a measurement of it, not an error:
+
+```csharp
+WaterProfile tap = new WaterProfileBuilder()
+    .AddCa(45).AddMg(12).AddS(18).AddNa(20).AddCl(25)
+    .Build();
+
+double meq = tap.EstimatedAlkalinity();                       // 2.27 meq/L
+Console.WriteLine($"{meq * 61:F0} ppm HCO3-");                // 139
+Console.WriteLine($"{meq * 50:F0} ppm as CaCO3");             // 114 — how water reports usually state it
+Console.WriteLine(tap.AsPpm().EstimateConductivity()
+    .MicroSiemensPerCm.ToString("F0"));                       // 358 µS/cm
+```
+
+That is also the acid needed per litre to neutralise the water, which is why it is worth surfacing: hard
+water pushes root-zone pH up all season if it is not accounted for. And the water's own EC is the quickest
+check that an analysis was typed in correctly — compare it with the meter reading you already have.
+
 Micronutrients are left out of the charge figures on purpose. Iron may be Fe²⁺ or Fe³⁺ and in chelated
 form the complex is an anion rather than a cation, so a charge for it would be a guess — and at under
 5 ppm in total they would move the balance by less than 0.1 meq/L against a typical 25–30. Boron and

--- a/README.md
+++ b/README.md
@@ -101,6 +101,47 @@ The remedies are outside the calculation — raise the target, or dilute the sou
 this surfaces instead of being hidden. `adjusted.Target` is an ordinary `PpmTarget`, so nothing
 downstream needs to know water was involved.
 
+## Judge the mix, not just compute it
+
+Absolute ppm figures say how strong a solution is; the ratios say what it will do.
+
+```csharp
+NutrientRatios ratios = calculator.CalculatePpm(mix, mix.WaterLiters).Ratios();
+
+Console.WriteLine($"NO3:NH4 {ratios.NitrateToAmmonium}");   // pH drift at the root
+Console.WriteLine($"K:Ca    {ratios.PotassiumToCalcium}");  // these compete for uptake
+Console.WriteLine($"Ca:Mg   {ratios.CalciumToMagnesium}");
+```
+
+`NitrateToAmmonium` is the one to watch most closely, because it predicts pH movement rather than
+nutrition: ammonium uptake acidifies the root zone, nitrate uptake alkalizes it. A ratio whose
+denominator is zero is `null` rather than zero or infinity — a nitrate-only mix is the everyday case,
+and reporting `0` or `∞` for it would mislead.
+
+To see which salt supplied what:
+
+```csharp
+foreach (FertilizerContribution part in mix.Breakdown(calculator))
+{
+    Console.WriteLine($"{part.Fertilizer.Name.Value}: S {part.Contribution.Sulfur.Value:F1} ppm");
+}
+```
+
+This answers what a bare recipe cannot — which salt is responsible for the sulfur you did not ask for:
+
+```
+salt                                     g      N      P      K     Ca     Mg      S
+Calcium Nitrate Tetrahydrate          58.9   69.9    0.0    0.0  100.0    0.0    0.0
+Potassium Nitrate                     35.4   49.0    0.0  136.9    0.0    0.0    0.0
+Magnesium Sulfate Heptahydrate        23.4    0.0    0.0    0.0    0.0   23.0   30.4
+Potassium Dihydrogen Phosphate        22.0    0.0   50.0   63.1    0.0    0.0    0.0
+Magnesium Nitrate Hexahydrate         28.4   31.1    0.0    0.0    0.0   27.0    0.0
+```
+
+Every salt brings a counter-ion along with the nutrient you wanted, so an unrequested element is rarely
+a mistake — it is the price of the element next to it. Contributions are measured through the same
+calculator as the whole mix, so the parts always sum to the total.
+
 ## Dependency injection
 
 Two ways, both supported. Pick by whether you would rather have one line or zero dependencies.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,59 @@ Every salt brings a counter-ion along with the nutrient you wanted, so an unrequ
 a mistake — it is the price of the element next to it. Contributions are measured through the same
 calculator as the whole mix, so the parts always sum to the total.
 
+## Mix once a month, not every watering
+
+Weighing six salts every time you water is what stops people using a calculated recipe. A concentrate
+solves that, and the two tanks exist for a chemical reason: calcium sulfate and the higher calcium
+phosphates are barely soluble, so what stays dissolved at working strength falls out of solution at
+100×.
+
+```csharp
+ConcentratePlan plan = mix.AsConcentrate(concentrateLiters: 1);
+
+Console.WriteLine($"1:{plan.DilutionRatio:F0}");          // 1:100
+Console.WriteLine($"{plan.MillilitresPerLiter:F0} ml");   // 10 ml of each tank per liter
+
+foreach (ConcentrateComponent c in plan.TankA.Components)
+{
+    Console.WriteLine($"{c.Fertilizer.Name.Value}: {c.Grams:F1} g ({c.GramsPerLiter:F1} g/L)");
+}
+```
+
+The whole recipe's salt goes into the smaller volume, so a 100-liter recipe concentrated into 1 liter is
+1:100. Concentrating changes how much water the salt goes into, never how much salt is needed — the
+weights are the working recipe's weights, which is why the finished solution still lands on target:
+
+```
+=== working mix, 100 L ===
+  Calcium Nitrate Tetrahydrate                  67.76 g  tank A
+  Potassium Nitrate                             37.98 g  tank A
+  Magnesium Sulfate Heptahydrate (MGS)          36.13 g  tank B
+  Ammonium Nitrate                               4.08 g  tank A
+  Potassium Dihydrogen Phosphate (MKP)          21.97 g  tank B
+  Magnesium Nitrate Hexahydrate (MAG)            2.50 g  tank A
+
+=== concentrate, 1 L per tank -> 1:100 ===
+dose: 10.0 ml of A + 10.0 ml of B per liter
+
+TANK A  (112.3 g/L total)
+TANK B  (58.1 g/L total)
+```
+
+Each salt's tank comes from its own `ConcentrateType`, which the preset catalogue already carries. A
+custom salt has none unless you set one, so a tank is inferred from its composition and the inference is
+reported in `Warnings` — guessing silently is how someone's own sulfate ends up next to calcium.
+
+`GramsPerLiter` is the figure to check against a salt's solubility. A recipe that dissolves happily at
+working strength can be impossible at 100×, and that limit binds per salt long before the tank total
+does.
+
+**On the precipitation check.** `HasPrecipitationRisk` flags calcium meeting sulfate or phosphate in one
+tank *from different salts*. It is a rule of thumb, not a solubility calculation. A single salt carrying
+both internally is not flagged — monocalcium phosphate is a soluble compound, not two reagents that
+happen to be adjacent, and a check that fired on it would teach you to ignore the check. Predicting
+actual precipitation needs solubility products, pH and temperature, none of which this library models.
+
 ## Dependency injection
 
 Two ways, both supported. Pick by whether you would rather have one line or zero dependencies.
@@ -209,7 +262,8 @@ runs.
 | --- | --- |
 | `SYT.NPKTools` | `Solution`, `Solutions`, `FertilizerSolutions`, the preset catalogue and the `NpkTools` factory |
 | `SYT.NPKTools.Fertilizers` | `Fertilizer`, its nutrient value objects and builders |
-| `SYT.NPKTools.Nutrients` | `Ppm`, `PpmTarget`, the ppm calculator and the target parser |
+| `SYT.NPKTools.Nutrients` | `Ppm`, `PpmTarget`, `WaterProfile`, `NutrientRatios`, the ppm calculator and the target parser |
+| `SYT.NPKTools.Concentrates` | `ConcentratePlan` and the A/B tank split |
 | `SYT.NPKTools.Optimization` | The linear program, the solver, the mapper and the settings |
 
 ## Runs in the browser

--- a/README.md
+++ b/README.md
@@ -447,6 +447,13 @@ Two checks run, and they catch different mistakes:
 `MaxDilutionRatio` is the answer to "then how strong *can* I make it": a 1:1000 concentrate that cannot
 dissolve may be fine at 1:600.
 
+**On the basis of these figures**, because it is where they go wrong. Each is grams of the salt *as the
+catalogue names it* — water of crystallisation included — per litre of water at 20 °C, and the source
+"g per 100 mL" entry sits in a comment beside every value so it can be re-checked. Handbooks report a
+hydrate two ways, as the hydrate or as the anhydrous salt inside it, and for magnesium sulfate those differ
+by a factor of two. Three of the table's figures were wrong on first writing for exactly that reason; all 21
+are now pinned by test against published values.
+
 **A salt with no published figure is reported, not assumed.** `SolubilityTable.Default` covers 21 of the
 catalogue's 34 salts. The rest — calcium chloride hexahydrate, urea phosphate, the EDTA chelates, sodium
 silicate and selenate, the nitrate micro salts — carry no entry, because the figures in circulation for

--- a/README.md
+++ b/README.md
@@ -193,6 +193,63 @@ solutions are run. Above pH 7.2 half of it is HPO₄²⁻. This library does not
 is stated rather than computed — and it is what makes the acid-base figures above come out in whole
 protons.
 
+## Predict what the EC meter will say
+
+EC is the number a grower actually measures, so predicting it is what connects a calculated recipe to the
+meter in the reservoir.
+
+```csharp
+ConductivityEstimate ec = ppm.EstimateConductivity();
+
+Console.WriteLine($"{ec.MilliSiemensPerCm:F2} mS/cm");   // 2.04
+Console.WriteLine($"{ec.AsTdsPpm(500):F0} ppm TDS");     // 1020 on a 500-scale meter
+```
+
+It is computed the way conductivity works — each ion's own molar conductivity times how much of it there
+is — not by scaling total dissolved solids by a fitted factor. That distinction is not academic: a mole of
+sulfate conducts more than twice what a mole of dihydrogen phosphate does, so two solutions of identical
+ppm can read differently, and a single factor cannot know which one it was handed.
+
+Which also means you can see what is driving the reading:
+
+```
+ion       µS/cm   share
+NO3         765   34.2%
+Ca          475   21.3%
+K           395   17.7%
+SO4         324   14.5%
+Mg          218    9.8%
+H2PO4        58    2.6%
+```
+
+**How accurate.** Checked against the certified KCl conductivity standards at 25 °C — the same reference
+solutions meters are calibrated against:
+
+| KCl | ideal sum | estimate | certified | error |
+| --- | --- | --- | --- | --- |
+| 0.001 M | 150 | 147 | 147 | **+0.1%** |
+| 0.01 M | 1498 | 1416 | 1412 | **+0.3%** |
+| 0.1 M | 14980 | 12375 | 12880 | −3.9% |
+
+The first two bracket the ionic strength of a real feed (0.02–0.04 M); the third is ten times stronger than
+anything you would grow in, and is shown to mark where the model stops being good.
+
+`IdealMicroSiemensPerCm` is the raw sum of limiting molar conductivities — exact for infinitely dilute
+water, and increasingly high above it because ions interfere with each other as they crowd.
+`MicroSiemensPerCm` applies a Kohlrausch-form correction for that, `Correction` is the factor it used
+(≈0.91 for a normal feed, i.e. the ideal sum runs 9% high), and `IonicStrength` is the exactly-computable
+quantity that decides it. Nothing is hidden behind a magic number: the one coefficient in the model comes
+from those certified standards, not from fitting to fertilizer recipes.
+
+Expect a few percent, not a meter replacement. The remaining error is not all the model's — the source
+water's bicarbonate conducts and is not modelled, meter calibration drifts, and temperature compensation
+is itself approximate.
+
+**Urea reads as pure water.** 150 ppm of nitrogen as urea gives an EC of exactly 0, because an uncharged
+molecule carries no current. That is not a bug to work around; it is the reason EC is a poor proxy for feed
+strength whenever urea is in the mix, and worth knowing before trusting a meter to tell you how strong a
+solution is.
+
 ## Use the salts you already have
 
 The preset catalogue offers eighteen macro bundles and therefore a dozen recipes to compare. Someone
@@ -425,7 +482,7 @@ runs.
 | --- | --- |
 | `SYT.NPKTools` | `Solution`, `Solutions`, `FertilizerSolutions`, the preset catalogue and the `NpkTools` factory |
 | `SYT.NPKTools.Fertilizers` | `Fertilizer`, its nutrient value objects and builders |
-| `SYT.NPKTools.Nutrients` | `Ppm`, `PpmTarget`, `WaterProfile`, `NutrientRatios`, `MolarProfile`, `IonBalance`, the ppm calculator and the target parser |
+| `SYT.NPKTools.Nutrients` | `Ppm`, `PpmTarget`, `WaterProfile`, `NutrientRatios`, `MolarProfile`, `IonBalance`, `ConductivityEstimate`, the ppm calculator and the target parser |
 | `SYT.NPKTools.Concentrates` | `ConcentratePlan` and the A/B tank split |
 | `SYT.NPKTools.Optimization` | The linear program, the solver, the mapper and the settings |
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,67 @@ Every salt brings a counter-ion along with the nutrient you wanted, so an unrequ
 a mistake — it is the price of the element next to it. Contributions are measured through the same
 calculator as the whole mix, so the parts always sum to the total.
 
+## Use the salts you already have
+
+The preset catalogue offers eighteen macro bundles and therefore a dozen recipes to compare. Someone
+working from their own shelf used to get one, because one list of salts is one bundle. Now the bundles
+are generated:
+
+```csharp
+Fertilizer[] shelf = [calciumNitrate, potassiumNitrate, magnesiumSulfate, mkp, sop, mag];
+
+IFertilizerOptimizationService service = NpkTools.CreateOptimizationService(shelf);
+Solutions recipes = service.FindMacroSolutions(target);   // several, not one
+```
+
+The first bundle holds everything on the shelf; each of the others leaves out one salt. That is the
+whole rule, and it is the one that measured best — alternatives can only come from taking something
+away, because handing the optimizer more salts than it needs yields the same best mix again. Removing
+one forces the linear program to route around it, which is both a different recipe and the question a
+grower actually asks: *what does this look like without the MKP?*
+
+Measured against the hand-written catalogue on three macro targets, counting distinct recipes returned:
+
+| bundle strategy | distinct recipes |
+| --- | --- |
+| one source per element, cross product | 5 |
+| hand-written catalogue (18 bundles) | 19 |
+| **hold one out** | **21** |
+| hold out pairs and triples as well | 21 |
+
+Holding out pairs adds nothing, because a smaller subset either reproduces a recipe already found or
+solves nothing at all. Building bundles up from per-element choices does badly for a reason worth
+knowing: six simultaneous element targets need at least six salts to satisfy at non-negative weights, and
+a bundle assembled as one-source-per-element rarely has that many once the overlaps collapse.
+
+To see what generation could not do, ask the repository rather than the service:
+
+```csharp
+CustomFertilizerBundleRepository bundles = NpkTools.CreateBundleRepository(shelf);
+
+if (!bundles.MacroGeneration.IsComplete)
+{
+    // ["Mg"] — no salt on the shelf supplies magnesium, so no bundle can meet a magnesium target
+    Console.WriteLine(string.Join(", ", bundles.MacroGeneration.UncoveredElements));
+}
+
+// Salts that carry nothing any target can ask for — table salt is the honest example
+Console.WriteLine(string.Join(", ", bundles.UnusableSalts));
+```
+
+This matters more than it looks. Without it a missing magnesium source shows up as "no solutions", which
+sends someone hunting through their shelf for a mistake that is not there.
+
+Macro and micro are split the way the preset catalogue splits them: carrying any micronutrient makes a
+salt a micro salt, even when it also carries a macro element. Iron sulfate's sulfur is incidental —
+dosing it to meet a sulfur target would mean iron at a hundred times the intended rate.
+
+Labelling a recipe is a set difference against the first bundle:
+
+```csharp
+string omitted = bundles.Macro()[0].Except(chosenBundle).Single().Name.Value;   // "without the SOP"
+```
+
 ## Mix once a month, not every watering
 
 Weighing six salts every time you water is what stops people using a calculated recipe. A concentrate

--- a/README.md
+++ b/README.md
@@ -61,6 +61,46 @@ using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
 Solutions solutions = optimizer.FindMacroSolutions(target, cts.Token);
 ```
 
+## Account for your source water
+
+Tap and well water is rarely blank, and whatever it carries is added on top of everything the
+fertilizers contribute. Deduct it before optimizing:
+
+```csharp
+WaterProfile tap = new WaterProfileBuilder()
+    .AddCa(45).AddMg(15).AddS(20).AddNa(25).AddCl(30).AddNitrate(6)
+    .Build();
+
+WaterAdjustedTarget adjusted = target.AdjustFor(tap);
+Solutions solutions = optimizer.FindMacroSolutions(adjusted.Target);
+```
+
+This is not a refinement. On the water above, a mix calculated against the raw target overshoots
+**calcium by 45%**, magnesium by 30% and sulfur by 33% — because the water supplies that much again on
+top. Deducting first lands every element exactly on target:
+
+| Element | Target | From mix | From water | Total | Deviation |
+| --- | --- | --- | --- | --- | --- |
+| Ca | 100 | 55 | 45 | 100 | 0% |
+| Mg | 50 | 35 | 15 | 50 | 0% |
+| S | 60 | 40 | 20 | 60 | 0% |
+
+Use `WaterProfile.Pure` for reverse osmosis, distilled or rain water; it leaves the target untouched.
+
+If the water already supplies more of something than you asked for, that element is reported rather
+than silently truncated — fertilizer only adds, so no mix can bring it down:
+
+```csharp
+foreach (NutrientExcess excess in adjusted.Excesses)
+{
+    Console.WriteLine($"{excess.Element}: water has {excess.InWater}, target {excess.Target}");
+}
+```
+
+The remedies are outside the calculation — raise the target, or dilute the source water — which is why
+this surfaces instead of being hidden. `adjusted.Target` is an ordinary `PpmTarget`, so nothing
+downstream needs to know water was involved.
+
 ## Dependency injection
 
 Two ways, both supported. Pick by whether you would rather have one line or zero dependencies.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <!-- Package metadata shared by every shipped library. -->
   <PropertyGroup>
-    <Version>1.0.0-preview.2</Version>
+    <Version>1.0.0-preview.3</Version>
     <Authors>Anatoliy Yermakov; Artem Frolov</Authors>
     <Company>SYT</Company>
     <Copyright>Copyright (c) Anatoliy Yermakov</Copyright>

--- a/src/SYT.NPKTools/Concentrates/ConcentrateComponent.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateComponent.cs
@@ -13,10 +13,39 @@ namespace SYT.NPKTools.Concentrates;
 /// How concentrated this salt ends up in the tank. This is the figure to check against the salt's
 /// solubility: a recipe that dissolves happily at working strength can be impossible at 100×.
 /// </param>
-public sealed record ConcentrateComponent(Fertilizer Fertilizer, double GramsPerLiter)
+/// <param name="SolubilityLimit">
+/// How much of this salt a litre of water holds at 20 °C, or null when no figure is known for it. Null is
+/// the honest answer for a custom salt and for the catalogue entries whose published figures disagree; see
+/// <see cref="SolubilityTable"/>.
+/// </param>
+public sealed record ConcentrateComponent(
+    Fertilizer Fertilizer,
+    double GramsPerLiter,
+    double? SolubilityLimit)
 {
     /// <summary>
     /// Gets the weight to measure out, in grams.
     /// </summary>
     public double Grams => Fertilizer.Weight.Value;
+
+    /// <summary>
+    /// Gets how much of this salt's solubility the tank uses, where 1 is saturated — or null when the
+    /// limit is unknown.
+    /// </summary>
+    /// <remarks>
+    /// Above 1 the salt cannot dissolve at this strength. Summed across a tank it becomes a screen for the
+    /// mixture as a whole; see <see cref="ConcentrateTank.SaturationFraction"/>.
+    /// </remarks>
+    public double? SaturationFraction =>
+        SolubilityLimit is null ? null : GramsPerLiter / SolubilityLimit.Value;
+
+    /// <summary>
+    /// Gets a value indicating whether this salt alone is asked to dissolve past its limit.
+    /// </summary>
+    /// <remarks>
+    /// The most certain signal in a concentrate plan: arithmetic against a published figure, rather than a
+    /// prediction. False when the limit is unknown, which is why
+    /// <see cref="ConcentratePlan.UnknownSolubility"/> has to be read alongside it.
+    /// </remarks>
+    public bool ExceedsSolubility => SaturationFraction > 1;
 }

--- a/src/SYT.NPKTools/Concentrates/ConcentrateComponent.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateComponent.cs
@@ -1,0 +1,22 @@
+using SYT.NPKTools.Fertilizers;
+
+namespace SYT.NPKTools.Concentrates;
+
+/// <summary>
+/// One fertilizer weighed into a concentrate tank.
+/// </summary>
+/// <param name="Fertilizer">
+/// The fertilizer, carrying the same weight the working solution called for. Concentrating changes how
+/// much water the salt goes into, never how much salt is needed.
+/// </param>
+/// <param name="GramsPerLiter">
+/// How concentrated this salt ends up in the tank. This is the figure to check against the salt's
+/// solubility: a recipe that dissolves happily at working strength can be impossible at 100×.
+/// </param>
+public sealed record ConcentrateComponent(Fertilizer Fertilizer, double GramsPerLiter)
+{
+    /// <summary>
+    /// Gets the weight to measure out, in grams.
+    /// </summary>
+    public double Grams => Fertilizer.Weight.Value;
+}

--- a/src/SYT.NPKTools/Concentrates/ConcentrateExtensions.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateExtensions.cs
@@ -150,19 +150,26 @@ public static class ConcentrateExtensions
     /// Works out how far a tank can be concentrated before it saturates.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Saturation rises in proportion to the dilution ratio — twice the ratio is twice the strength — so
-    /// the ceiling is where the summed fractions reach 1. Returns null when any salt's limit is unknown, or
-    /// when nothing in the tank has a finite limit to bind against.
+    /// the ceiling is where the summed fractions reach 1. Returns null only when nothing in the tank has a
+    /// finite known limit to bind against.
+    /// </para>
+    /// <para>
+    /// Salts with no known limit are skipped rather than making the whole tank unbounded. Skipping them
+    /// loosens the bound, which is a shame; treating the tank as unconstrained would <em>discard</em> the
+    /// limits that are known, which is a defect — a tank holding one custom salt beside an over-limit MKP
+    /// would report a ceiling taken from the other tank entirely, tens of times too high. This is the one
+    /// place where the reasoning differs from <see cref="ConcentrateTank.SaturationFraction"/>, which is
+    /// null on an unknown because a partial sum there would read as a verdict on the tank. Here a partial
+    /// bound is still a bound, and the salts left out of it are named in
+    /// <see cref="ConcentratePlan.UnknownSolubility"/>.
+    /// </para>
     /// </remarks>
     private static double? CeilingFor(ConcentrateTank tank, double workingLiters)
     {
-        if (tank.IsEmpty || tank.Components.Any(c => c.SolubilityLimit is null))
-        {
-            return null;
-        }
-
         double saturationPerUnitRatio = tank.Components
-            .Where(c => double.IsFinite(c.SolubilityLimit!.Value))
+            .Where(c => c.SolubilityLimit is not null && double.IsFinite(c.SolubilityLimit.Value))
             .Sum(c => c.Grams / (workingLiters * c.SolubilityLimit!.Value));
 
         return saturationPerUnitRatio > 0 ? 1 / saturationPerUnitRatio : null;

--- a/src/SYT.NPKTools/Concentrates/ConcentrateExtensions.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateExtensions.cs
@@ -17,6 +17,11 @@ public static class ConcentrateExtensions
     /// The volume of each tank. The whole recipe's salt goes into this much water, so a 100-liter recipe
     /// concentrated into 1 liter gives a 1:100 dilution.
     /// </param>
+    /// <param name="solubility">
+    /// The solubility figures to check each salt's tank strength against. Defaults to
+    /// <see cref="SolubilityTable.Default"/>, which covers the preset catalogue; add your own salts with
+    /// <see cref="SolubilityTable.With"/>, since a salt with no figure can only be reported as unchecked.
+    /// </param>
     /// <returns>The tanks, the dilution ratio, and anything worth checking before mixing.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="solution"/> is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">
@@ -38,10 +43,15 @@ public static class ConcentrateExtensions
     /// needs solubility products, pH and temperature, none of which this library models.
     /// </para>
     /// </remarks>
-    public static ConcentratePlan AsConcentrate(this Solution solution, double concentrateLiters)
+    public static ConcentratePlan AsConcentrate(
+        this Solution solution,
+        double concentrateLiters,
+        SolubilityTable? solubility = null)
     {
         ArgumentNullException.ThrowIfNull(solution);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(concentrateLiters);
+
+        solubility ??= SolubilityTable.Default;
 
         if (concentrateLiters >= solution.WaterLiters)
         {
@@ -70,8 +80,10 @@ public static class ConcentrateExtensions
                         + "composition. Set ConcentrateType explicitly to be sure."));
             }
 
-            ConcentrateComponent component =
-                new(fertilizer, fertilizer.Weight.Value / concentrateLiters);
+            ConcentrateComponent component = new(
+                fertilizer,
+                fertilizer.Weight.Value / concentrateLiters,
+                solubility.Limit(fertilizer.Name.Value));
 
             if (tank == ConcentrateType.B)
             {
@@ -86,13 +98,78 @@ public static class ConcentrateExtensions
         warnings.AddRange(FindPrecipitationRisks(ConcentrateType.A, tankA));
         warnings.AddRange(FindPrecipitationRisks(ConcentrateType.B, tankB));
 
+        ConcentrateTank tankOfA = new(ConcentrateType.A, tankA);
+        ConcentrateTank tankOfB = new(ConcentrateType.B, tankB);
+
+        List<string> unknownSolubility = [];
+        double? maxRatio = null;
+
+        foreach (ConcentrateTank tank in new[] { tankOfA, tankOfB })
+        {
+            unknownSolubility.AddRange(tank.Components
+                .Where(c => c.SolubilityLimit is null)
+                .Select(c => c.Fertilizer.Name.Value));
+
+            warnings.AddRange(tank.Components
+                .Where(c => c.ExceedsSolubility)
+                .Select(c => new ConcentrateWarning(
+                    ConcentrateWarningKind.SolubilityExceeded,
+                    tank.Tank,
+                    [c.Fertilizer.Name.Value],
+                    $"Tank {tank.Tank} needs {c.GramsPerLiter:F1} g/L of '{c.Fertilizer.Name.Value}', "
+                        + $"which dissolves to {c.SolubilityLimit:F0} g/L at 20 °C. Use a larger "
+                        + "concentrate volume, or a more soluble source of that element.")));
+
+            if (tank.IsSaturated)
+            {
+                warnings.Add(new ConcentrateWarning(
+                    ConcentrateWarningKind.TankSaturated,
+                    tank.Tank,
+                    [.. tank.Components.Select(c => c.Fertilizer.Name.Value)],
+                    $"Tank {tank.Tank} is at {tank.SaturationFraction:P0} of saturation: its salts "
+                        + "together need more water than the tank holds, because they compete for the "
+                        + "same water. Use a larger concentrate volume."));
+            }
+
+            maxRatio = Smaller(maxRatio, CeilingFor(tank, solution.WaterLiters));
+        }
+
         return new ConcentratePlan(
-            new ConcentrateTank(ConcentrateType.A, tankA),
-            new ConcentrateTank(ConcentrateType.B, tankB),
+            tankOfA,
+            tankOfB,
             concentrateLiters,
             solution.WaterLiters,
-            warnings);
+            warnings,
+            unknownSolubility)
+        {
+            MaxDilutionRatio = maxRatio
+        };
     }
+
+    /// <summary>
+    /// Works out how far a tank can be concentrated before it saturates.
+    /// </summary>
+    /// <remarks>
+    /// Saturation rises in proportion to the dilution ratio — twice the ratio is twice the strength — so
+    /// the ceiling is where the summed fractions reach 1. Returns null when any salt's limit is unknown, or
+    /// when nothing in the tank has a finite limit to bind against.
+    /// </remarks>
+    private static double? CeilingFor(ConcentrateTank tank, double workingLiters)
+    {
+        if (tank.IsEmpty || tank.Components.Any(c => c.SolubilityLimit is null))
+        {
+            return null;
+        }
+
+        double saturationPerUnitRatio = tank.Components
+            .Where(c => double.IsFinite(c.SolubilityLimit!.Value))
+            .Sum(c => c.Grams / (workingLiters * c.SolubilityLimit!.Value));
+
+        return saturationPerUnitRatio > 0 ? 1 / saturationPerUnitRatio : null;
+    }
+
+    private static double? Smaller(double? left, double? right) =>
+        left is null ? right : right is null ? left : Math.Min(left.Value, right.Value);
 
     /// <summary>
     /// Picks a tank for a fertilizer that does not declare one, from what it contains.

--- a/src/SYT.NPKTools/Concentrates/ConcentrateExtensions.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateExtensions.cs
@@ -1,0 +1,165 @@
+using SYT.NPKTools.Fertilizers;
+
+namespace SYT.NPKTools.Concentrates;
+
+/// <summary>
+/// Turns a working-strength recipe into concentrate tanks.
+/// </summary>
+public static class ConcentrateExtensions
+{
+    /// <summary>
+    /// Splits a mix into two concentrate tanks, keeping calcium away from sulfate and phosphate.
+    /// </summary>
+    /// <param name="solution">
+    /// The mix as the optimizer produced it, carrying the weights for its own water volume.
+    /// </param>
+    /// <param name="concentrateLiters">
+    /// The volume of each tank. The whole recipe's salt goes into this much water, so a 100-liter recipe
+    /// concentrated into 1 liter gives a 1:100 dilution.
+    /// </param>
+    /// <returns>The tanks, the dilution ratio, and anything worth checking before mixing.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="solution"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="concentrateLiters"/> is not positive, or is not smaller than the mix's
+    /// own water volume — a "concentrate" at or above working volume is not concentrating anything.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Each fertilizer's own <see cref="Fertilizer.Type"/> decides its tank. Where that is
+    /// <see cref="ConcentrateType.None"/> — which is what a custom salt gets unless its author says
+    /// otherwise — a tank is inferred from the composition and the inference is reported, because
+    /// guessing silently is how a custom sulfate ends up next to calcium.
+    /// </para>
+    /// <para>
+    /// The precipitation check is a rule of thumb, not a solubility calculation: it flags calcium and
+    /// sulfate or phosphate arriving in one tank from <em>different</em> salts. A single salt carrying
+    /// both internally — monocalcium phosphate, for instance — is not flagged, because it is a soluble
+    /// compound rather than two reagents that happen to be adjacent. Predicting actual precipitation
+    /// needs solubility products, pH and temperature, none of which this library models.
+    /// </para>
+    /// </remarks>
+    public static ConcentratePlan AsConcentrate(this Solution solution, double concentrateLiters)
+    {
+        ArgumentNullException.ThrowIfNull(solution);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(concentrateLiters);
+
+        if (concentrateLiters >= solution.WaterLiters)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(concentrateLiters),
+                concentrateLiters,
+                $"A concentrate must hold less water than the working solution ({solution.WaterLiters} L).");
+        }
+
+        List<ConcentrateWarning> warnings = [];
+        List<ConcentrateComponent> tankA = [];
+        List<ConcentrateComponent> tankB = [];
+
+        foreach (Fertilizer fertilizer in solution)
+        {
+            ConcentrateType tank = fertilizer.Type;
+
+            if (tank == ConcentrateType.None)
+            {
+                tank = Infer(fertilizer);
+                warnings.Add(new ConcentrateWarning(
+                    ConcentrateWarningKind.TankInferred,
+                    tank,
+                    [fertilizer.Name.Value],
+                    $"'{fertilizer.Name.Value}' has no tank assigned; tank {tank} was inferred from its "
+                        + "composition. Set ConcentrateType explicitly to be sure."));
+            }
+
+            ConcentrateComponent component =
+                new(fertilizer, fertilizer.Weight.Value / concentrateLiters);
+
+            if (tank == ConcentrateType.B)
+            {
+                tankB.Add(component);
+            }
+            else
+            {
+                tankA.Add(component);
+            }
+        }
+
+        warnings.AddRange(FindPrecipitationRisks(ConcentrateType.A, tankA));
+        warnings.AddRange(FindPrecipitationRisks(ConcentrateType.B, tankB));
+
+        return new ConcentratePlan(
+            new ConcentrateTank(ConcentrateType.A, tankA),
+            new ConcentrateTank(ConcentrateType.B, tankB),
+            concentrateLiters,
+            solution.WaterLiters,
+            warnings);
+    }
+
+    /// <summary>
+    /// Picks a tank for a fertilizer that does not declare one, from what it contains.
+    /// </summary>
+    /// <remarks>
+    /// Calcium goes to A and sulfate or phosphate to B, which is the convention the tanks exist to serve.
+    /// A salt carrying calcium <em>and</em> phosphate internally goes to B: it is soluble in itself, and B
+    /// is where the phosphate it would otherwise meet already is. Anything carrying none of the three —
+    /// a nitrate, urea — is chemically welcome in either, and lands in A because that is where the
+    /// convention puts the bulk of the nitrogen.
+    /// </remarks>
+    private static ConcentrateType Infer(Fertilizer fertilizer)
+    {
+        bool hasSulfateOrPhosphate = fertilizer.Sulfur.Value > 0 || fertilizer.Phosphorus.Value > 0;
+
+        if (hasSulfateOrPhosphate)
+        {
+            return ConcentrateType.B;
+        }
+
+        return ConcentrateType.A;
+    }
+
+    /// <summary>
+    /// Flags calcium meeting sulfate or phosphate in one tank, from separate salts.
+    /// </summary>
+    private static IEnumerable<ConcentrateWarning> FindPrecipitationRisks(
+        ConcentrateType tank,
+        IReadOnlyList<ConcentrateComponent> components)
+    {
+        List<string> calciumSources = [];
+        List<string> sulfateOrPhosphateSources = [];
+
+        foreach (ConcentrateComponent component in components)
+        {
+            Fertilizer fertilizer = component.Fertilizer;
+            bool hasCalcium = fertilizer.Calcium.Value > 0;
+            bool hasSulfateOrPhosphate = fertilizer.Sulfur.Value > 0 || fertilizer.Phosphorus.Value > 0;
+
+            // A salt holding both is a compound, not a collision, so it counts as neither source.
+            if (hasCalcium && hasSulfateOrPhosphate)
+            {
+                continue;
+            }
+
+            if (hasCalcium)
+            {
+                calciumSources.Add(fertilizer.Name.Value);
+            }
+            else if (hasSulfateOrPhosphate)
+            {
+                sulfateOrPhosphateSources.Add(fertilizer.Name.Value);
+            }
+        }
+
+        if (calciumSources.Count == 0 || sulfateOrPhosphateSources.Count == 0)
+        {
+            yield break;
+        }
+
+        yield return new ConcentrateWarning(
+            ConcentrateWarningKind.PrecipitationRisk,
+            tank,
+            [.. calciumSources, .. sulfateOrPhosphateSources],
+            $"Tank {tank} holds calcium ({string.Join(", ", calciumSources)}) together with sulfate or "
+                + $"phosphate ({string.Join(", ", sulfateOrPhosphateSources)}). These precipitate at "
+                + "concentrate strength even though they stay dissolved at working strength. Move one "
+                + "group to the other tank.");
+    }
+}

--- a/src/SYT.NPKTools/Concentrates/ConcentratePlan.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentratePlan.cs
@@ -1,0 +1,70 @@
+using SYT.NPKTools.Fertilizers;
+
+namespace SYT.NPKTools.Concentrates;
+
+/// <summary>
+/// A recipe split into concentrate tanks, ready to mix and store.
+/// </summary>
+/// <param name="TankA">
+/// Tank A, conventionally the calcium-bearing salts.
+/// </param>
+/// <param name="TankB">
+/// Tank B, conventionally the sulfates and phosphates that would precipitate calcium if stored
+/// alongside it.
+/// </param>
+/// <param name="ConcentrateLiters">The volume of each tank.</param>
+/// <param name="WorkingLiters">The volume of working solution the original recipe was for.</param>
+/// <param name="Warnings">Anything worth checking before mixing. Empty is the good case.</param>
+/// <remarks>
+/// <para>
+/// A concentrate exists so that mixing happens once a month instead of every watering. The catch is
+/// chemical: calcium sulfate and the higher calcium phosphates are barely soluble, so at working
+/// strength they stay dissolved while at concentrate strength they fall out of solution. Keeping calcium
+/// apart from sulfate and phosphate until the moment of final dilution is what the two tanks are for.
+/// </para>
+/// <para>
+/// The weights are the same as the working recipe called for — concentrating changes the volume of
+/// water, not the amount of salt.
+/// </para>
+/// </remarks>
+public sealed record ConcentratePlan(
+    ConcentrateTank TankA,
+    ConcentrateTank TankB,
+    double ConcentrateLiters,
+    double WorkingLiters,
+    IReadOnlyList<ConcentrateWarning> Warnings)
+{
+    /// <summary>
+    /// Gets how many parts of water each part of concentrate is diluted into.
+    /// </summary>
+    /// <remarks>
+    /// A ratio of 100 means 10 ml of tank A and 10 ml of tank B per liter of finished solution. Both
+    /// tanks share the same ratio, which is what lets them be dosed together.
+    /// </remarks>
+    public double DilutionRatio => WorkingLiters / ConcentrateLiters;
+
+    /// <summary>
+    /// Gets the millilitres of each tank to add per liter of finished solution.
+    /// </summary>
+    public double MillilitresPerLiter => 1000d / DilutionRatio;
+
+    /// <summary>
+    /// Gets both tanks.
+    /// </summary>
+    public IReadOnlyList<ConcentrateTank> Tanks => [TankA, TankB];
+
+    /// <summary>
+    /// Gets a value indicating whether anything in this plan needs checking before mixing.
+    /// </summary>
+    public bool HasWarnings => Warnings.Count > 0;
+
+    /// <summary>
+    /// Gets a value indicating whether any tank is expected to precipitate.
+    /// </summary>
+    /// <remarks>
+    /// The one flag worth blocking on. Other warnings are advisory; this one means the batch is likely to
+    /// be wasted.
+    /// </remarks>
+    public bool HasPrecipitationRisk =>
+        Warnings.Any(w => w.Kind == ConcentrateWarningKind.PrecipitationRisk);
+}

--- a/src/SYT.NPKTools/Concentrates/ConcentratePlan.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentratePlan.cs
@@ -15,6 +15,10 @@ namespace SYT.NPKTools.Concentrates;
 /// <param name="ConcentrateLiters">The volume of each tank.</param>
 /// <param name="WorkingLiters">The volume of working solution the original recipe was for.</param>
 /// <param name="Warnings">Anything worth checking before mixing. Empty is the good case.</param>
+/// <param name="UnknownSolubility">
+/// Names of salts the solubility table had no figure for, so nothing could be checked. Reported rather
+/// than passed over: "we do not know whether this dissolves" must not read as "this dissolves".
+/// </param>
 /// <remarks>
 /// <para>
 /// A concentrate exists so that mixing happens once a month instead of every watering. The catch is
@@ -32,7 +36,8 @@ public sealed record ConcentratePlan(
     ConcentrateTank TankB,
     double ConcentrateLiters,
     double WorkingLiters,
-    IReadOnlyList<ConcentrateWarning> Warnings)
+    IReadOnlyList<ConcentrateWarning> Warnings,
+    IReadOnlyList<string> UnknownSolubility)
 {
     /// <summary>
     /// Gets how many parts of water each part of concentrate is diluted into.
@@ -67,4 +72,28 @@ public sealed record ConcentratePlan(
     /// </remarks>
     public bool HasPrecipitationRisk =>
         Warnings.Any(w => w.Kind == ConcentrateWarningKind.PrecipitationRisk);
+
+    /// <summary>
+    /// Gets a value indicating whether any salt is asked to dissolve past its solubility.
+    /// </summary>
+    /// <remarks>
+    /// The other flag worth blocking on, and the more certain of the two: precipitation is a prediction,
+    /// whereas this is arithmetic against a published figure. Dilute the concentrate — a larger tank at a
+    /// smaller ratio — or pick a more soluble source of the element.
+    /// </remarks>
+    public bool ExceedsSolubility =>
+        Warnings.Any(w => w.Kind is ConcentrateWarningKind.SolubilityExceeded
+                                 or ConcentrateWarningKind.TankSaturated);
+
+    /// <summary>
+    /// Gets the largest concentrate volume ratio the solubility figures allow, or null when no salt has a
+    /// known limit.
+    /// </summary>
+    /// <remarks>
+    /// The actionable number when <see cref="ExceedsSolubility"/> is true: a 1:100 concentrate that cannot
+    /// dissolve may well work at 1:40, and this says where the ceiling is. It is an upper bound on
+    /// <see cref="DilutionRatio"/> and shares the caveats of the table it comes from — the true ceiling in
+    /// a mixture is lower, so leave headroom.
+    /// </remarks>
+    public double? MaxDilutionRatio { get; init; }
 }

--- a/src/SYT.NPKTools/Concentrates/ConcentratePlan.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentratePlan.cs
@@ -86,14 +86,20 @@ public sealed record ConcentratePlan(
                                  or ConcentrateWarningKind.TankSaturated);
 
     /// <summary>
-    /// Gets the largest concentrate volume ratio the solubility figures allow, or null when no salt has a
-    /// known limit.
+    /// Gets the largest dilution ratio the known solubility figures allow, or null when no salt in either
+    /// tank has a finite known limit.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The actionable number when <see cref="ExceedsSolubility"/> is true: a 1:100 concentrate that cannot
-    /// dissolve may well work at 1:40, and this says where the ceiling is. It is an upper bound on
-    /// <see cref="DilutionRatio"/> and shares the caveats of the table it comes from — the true ceiling in
-    /// a mixture is lower, so leave headroom.
+    /// dissolve may well work at 1:40, and this says where the ceiling is. It shares the caveats of the
+    /// table it comes from — the true ceiling in a mixture is lower, so leave headroom.
+    /// </para>
+    /// <para>
+    /// Salts named in <see cref="UnknownSolubility"/> are not part of this bound, because there is no figure
+    /// to bound them with. That makes the ceiling an optimistic one whenever that list is non-empty: the real
+    /// limit may be lower, and it is the caller's job to read the two together.
+    /// </para>
     /// </remarks>
     public double? MaxDilutionRatio { get; init; }
 }

--- a/src/SYT.NPKTools/Concentrates/ConcentratePlan.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentratePlan.cs
@@ -1,5 +1,3 @@
-using SYT.NPKTools.Fertilizers;
-
 namespace SYT.NPKTools.Concentrates;
 
 /// <summary>

--- a/src/SYT.NPKTools/Concentrates/ConcentrateTank.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateTank.cs
@@ -1,0 +1,35 @@
+using SYT.NPKTools.Fertilizers;
+
+namespace SYT.NPKTools.Concentrates;
+
+/// <summary>
+/// One stock tank of a concentrate: which salts go in it, and how concentrated each ends up.
+/// </summary>
+/// <param name="Tank">Which tank this is.</param>
+/// <param name="Components">The salts to weigh into it, in the mix's own order.</param>
+public sealed record ConcentrateTank(ConcentrateType Tank, IReadOnlyList<ConcentrateComponent> Components)
+{
+    /// <summary>
+    /// Gets the total weight of salt going into this tank, in grams.
+    /// </summary>
+    public double TotalGrams => Components.Sum(c => c.Grams);
+
+    /// <summary>
+    /// Gets the total dissolved solids this tank will hold, in grams per liter.
+    /// </summary>
+    /// <remarks>
+    /// A rough feasibility signal for the tank as a whole. Individual salts have their own solubility
+    /// limits and one of them will usually bind before this total does, so treat a comfortable figure
+    /// here as necessary rather than sufficient.
+    /// </remarks>
+    public double TotalGramsPerLiter => Components.Sum(c => c.GramsPerLiter);
+
+    /// <summary>
+    /// Gets a value indicating whether this tank has nothing in it.
+    /// </summary>
+    /// <remarks>
+    /// Normal rather than a problem: a mix of only nitrates and phosphates has no calcium to keep apart,
+    /// so a single tank is enough and the other stays empty.
+    /// </remarks>
+    public bool IsEmpty => Components.Count == 0;
+}

--- a/src/SYT.NPKTools/Concentrates/ConcentrateTank.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateTank.cs
@@ -18,11 +18,43 @@ public sealed record ConcentrateTank(ConcentrateType Tank, IReadOnlyList<Concent
     /// Gets the total dissolved solids this tank will hold, in grams per liter.
     /// </summary>
     /// <remarks>
-    /// A rough feasibility signal for the tank as a whole. Individual salts have their own solubility
-    /// limits and one of them will usually bind before this total does, so treat a comfortable figure
-    /// here as necessary rather than sufficient.
+    /// On its own this says less than it appears to, because salts differ enormously in how much will
+    /// dissolve: 600 g/L of calcium nitrate is comfortable and 600 g/L of monocalcium phosphate is thirty
+    /// times impossible. <see cref="SaturationFraction"/> is the figure to judge a tank by.
     /// </remarks>
     public double TotalGramsPerLiter => Components.Sum(c => c.GramsPerLiter);
+
+    /// <summary>
+    /// Gets how saturated the tank is: each salt's share of its own solubility, added up. 1 is saturated.
+    /// Null when any salt in the tank has no known limit.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Salts in one tank compete for the same water, so checking each against its own limit in isolation
+    /// is too permissive — four salts each at 40% of their limit will not dissolve, though none of them
+    /// individually exceeds anything. Adding the fractions is the standard first-order screen for that: it
+    /// is exact for a single salt and approximate for a mixture, erring slightly optimistic because salts
+    /// sharing an ion crowd each other out more than the sum suggests.
+    /// </para>
+    /// <para>
+    /// Null rather than a partial sum when a limit is missing. A sum over the known salts only would read
+    /// as a verdict on the tank while silently omitting a term, and the omitted salt could be the one that
+    /// binds.
+    /// </para>
+    /// </remarks>
+    public double? SaturationFraction =>
+        Components.Any(c => c.SolubilityLimit is null)
+            ? null
+            : Components.Sum(c => c.SaturationFraction!.Value);
+
+    /// <summary>
+    /// Gets a value indicating whether the tank is beyond saturation and will not dissolve as specified.
+    /// </summary>
+    /// <remarks>
+    /// False when <see cref="SaturationFraction"/> is unknown, so read
+    /// <see cref="ConcentratePlan.UnknownSolubility"/> alongside it rather than treating false as safe.
+    /// </remarks>
+    public bool IsSaturated => SaturationFraction > 1;
 
     /// <summary>
     /// Gets a value indicating whether this tank has nothing in it.

--- a/src/SYT.NPKTools/Concentrates/ConcentrateWarning.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateWarning.cs
@@ -18,7 +18,24 @@ public enum ConcentrateWarningKind
     /// A fertilizer carried no tank assignment, so one was inferred from its composition. Worth
     /// checking rather than trusting — the inference is a rule of thumb, not chemistry.
     /// </summary>
-    TankInferred
+    TankInferred,
+
+    /// <summary>
+    /// A salt is asked to dissolve past its solubility, so the tank cannot be mixed as specified. The
+    /// most certain of the three: precipitation is a prediction and an inferred tank is a guess, but this
+    /// is arithmetic against a published figure. Dilute the concentrate or change the source of that
+    /// element.
+    /// </summary>
+    SolubilityExceeded,
+
+    /// <summary>
+    /// The salts in one tank together need more water than the tank holds, even though none of them
+    /// individually exceeds its own limit. They compete for the same water, so four salts each at 40% of
+    /// their solubility will not dissolve. Less certain than
+    /// <see cref="SolubilityExceeded"/> — it is a first-order screen rather than a single published
+    /// figure — but it is the check that catches an over-concentrated tank of otherwise soluble salts.
+    /// </summary>
+    TankSaturated
 }
 
 /// <summary>

--- a/src/SYT.NPKTools/Concentrates/ConcentrateWarning.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateWarning.cs
@@ -1,0 +1,35 @@
+using SYT.NPKTools.Fertilizers;
+
+namespace SYT.NPKTools.Concentrates;
+
+/// <summary>
+/// What kind of problem a <see cref="ConcentrateWarning"/> describes.
+/// </summary>
+public enum ConcentrateWarningKind
+{
+    /// <summary>
+    /// Salts in one tank that will precipitate each other once concentrated. This is the warning that
+    /// ruins a batch: the tank goes cloudy, solids settle out, and the nutrients they carried never
+    /// reach the plants even though the arithmetic was correct.
+    /// </summary>
+    PrecipitationRisk,
+
+    /// <summary>
+    /// A fertilizer carried no tank assignment, so one was inferred from its composition. Worth
+    /// checking rather than trusting — the inference is a rule of thumb, not chemistry.
+    /// </summary>
+    TankInferred
+}
+
+/// <summary>
+/// Something worth knowing before mixing a concentrate.
+/// </summary>
+/// <param name="Kind">What sort of problem this is.</param>
+/// <param name="Tank">The tank it concerns.</param>
+/// <param name="Fertilizers">The fertilizers involved, so a caller can point at them.</param>
+/// <param name="Message">A description suitable for showing to a person.</param>
+public sealed record ConcentrateWarning(
+    ConcentrateWarningKind Kind,
+    ConcentrateType Tank,
+    IReadOnlyList<string> Fertilizers,
+    string Message);

--- a/src/SYT.NPKTools/Concentrates/SolubilityTable.cs
+++ b/src/SYT.NPKTools/Concentrates/SolubilityTable.cs
@@ -66,38 +66,53 @@ public sealed class SolubilityTable
     /// Gets the built-in table, covering the salts in the preset catalogue whose published figures agree.
     /// </summary>
     /// <remarks>
-    /// Values are the ordinary handbook solubilities at 20 °C for the hydrate the catalogue names. The two
-    /// worth knowing by heart are the low ones, because they are what a concentrate actually runs into:
-    /// monocalcium phosphate at 18 g/L and boric acid at 49 g/L will bind long before potassium nitrate's
+    /// <para>
+    /// <b>The basis, which is the part that goes wrong.</b> Every figure is grams of the salt <em>as the
+    /// catalogue names it</em> — including its water of crystallisation — per litre of water at 20 °C. It is
+    /// ten times the handbook "g per 100 mL" entry for that named hydrate, and the trailing comment on each
+    /// line is that entry, so any value can be checked against a reference without unit arithmetic.
+    /// </para>
+    /// <para>
+    /// Getting the basis wrong is the standard way this table becomes dangerous, because handbooks report
+    /// hydrates two ways: as the hydrate, or as the anhydrous salt it contains. Magnesium sulfate is 71 g of
+    /// the heptahydrate per 100 mL but only 35 g of anhydrous MgSO₄ — a factor of two, and the same figure
+    /// appears in circulation under both labels. Three entries here were wrong on a first pass for exactly
+    /// this reason and were corrected against published values; two of them were wrong in the direction that
+    /// passes a tank which cannot dissolve.
+    /// </para>
+    /// <para>
+    /// The two worth knowing by heart are the low ones, because they are what a concentrate actually runs
+    /// into: monocalcium phosphate at 18 g/L and boric acid at 49 g/L bind long before potassium nitrate's
     /// 316 does.
+    /// </para>
     /// </remarks>
     public static SolubilityTable Default { get; } = new(new Dictionary<string, double>
     {
         // Macro salts.
-        ["Calcium Nitrate Tetrahydrate"] = 1290,
-        ["Potassium Nitrate"] = 316,
-        ["Magnesium Sulfate Heptahydrate (MGS)"] = 710,
-        ["Magnesium Nitrate Hexahydrate (MAG)"] = 1250,
-        ["Potassium Dihydrogen Phosphate (MKP)"] = 226,
-        ["Potassium Dibasic Phosphate"] = 1490,
-        ["Monoammonium Phosphate"] = 383,
-        ["Calcium Monobasic Phosphate"] = 18,
-        ["Potassium Sulfate (SOP)"] = 111,
-        ["Ammonium Sulfate"] = 754,
-        ["Ammonium Nitrate"] = 1500,
-        ["Ammonium Chloride"] = 372,
-        ["Potassium Chloride"] = 344,
-        ["Urea"] = 1080,
-        ["Phosphoric Acid"] = double.PositiveInfinity,
+        ["Calcium Nitrate Tetrahydrate"] = 1290,     // 129 g/100 mL
+        ["Potassium Nitrate"] = 316,                 // 31.6
+        ["Magnesium Sulfate Heptahydrate (MGS)"] = 710,   // 71
+        ["Magnesium Nitrate Hexahydrate (MAG)"] = 420,    // 42
+        ["Potassium Dihydrogen Phosphate (MKP)"] = 226,   // 22.6
+        ["Potassium Dibasic Phosphate"] = 1490,      // 149.25
+        ["Monoammonium Phosphate"] = 383,            // 38.3
+        ["Calcium Monobasic Phosphate"] = 18,        // 1.8% — the lowest in the table
+        ["Potassium Sulfate (SOP)"] = 111,           // 11.1
+        ["Ammonium Sulfate"] = 754,                  // 75.4
+        ["Ammonium Nitrate"] = 1920,                 // 192
+        ["Ammonium Chloride"] = 372,                 // 37.2
+        ["Potassium Chloride"] = 344,                // 34.4
+        ["Urea"] = 1080,                             // 108
+        ["Phosphoric Acid"] = double.PositiveInfinity,    // miscible
 
         // Micro salts. Boric acid and borax matter most: they are barely soluble and boron is dosed high
         // enough for the limit to bind at concentrate strength.
-        ["Boric Acid"] = 49,
-        ["Sodium Borate Decahydrate"] = 51,
-        ["Iron(II) Sulfate Heptahydrate"] = 256,
-        ["Copper Sulfate Pentahydrate"] = 320,
-        ["Zinc Sulfate Monohydrate"] = 600,
-        ["Sodium Molybdate Dihydrate"] = 840,
+        ["Boric Acid"] = 49,                         // 4.95
+        ["Sodium Borate Decahydrate"] = 51,          // 5.1
+        ["Iron(II) Sulfate Heptahydrate"] = 256,     // 25.6
+        ["Copper Sulfate Pentahydrate"] = 320,       // 32
+        ["Zinc Sulfate Monohydrate"] = 350,          // 35 — the monohydrate; the heptahydrate is 965
+        ["Sodium Molybdate Dihydrate"] = 840,        // 84
     });
 
     /// <summary>

--- a/src/SYT.NPKTools/Concentrates/SolubilityTable.cs
+++ b/src/SYT.NPKTools/Concentrates/SolubilityTable.cs
@@ -1,0 +1,151 @@
+namespace SYT.NPKTools.Concentrates;
+
+/// <summary>
+/// How much of each salt will dissolve in a litre of water, in grams, at 20 °C.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A concentrate is the one place in this library where a recipe can be arithmetically perfect and
+/// physically impossible. <see cref="ConcentrateComponent.GramsPerLiter"/> says how strong a salt ends up
+/// in its tank; this says how strong it can get. Without the second number the first is just a figure to
+/// look at.
+/// </para>
+/// <para>
+/// <b>These are screening values, not guarantees.</b> Three things make them approximate. Solubility rises
+/// steeply with temperature, and 20 °C is a cool garage rather than a warm one. In a mixture the practical
+/// limit for each salt is <em>lower</em> than in pure water, because salts sharing an ion crowd each other
+/// out — two potassium salts in one tank will bind sooner than either alone. And a hydrate's figure
+/// depends on which hydrate was weighed. So exceeding a limit here means the tank will certainly not
+/// dissolve; staying under it means only that this particular obstacle is clear.
+/// </para>
+/// <para>
+/// <b>Salts deliberately absent.</b> Calcium chloride hexahydrate, urea phosphate, manganese sulfate
+/// monohydrate, the nitrate micro salts, the EDTA chelates, sodium silicate and sodium selenate carry no
+/// entry, because the figures in circulation for them disagree by more than the check would be worth — a
+/// chelate's solubility depends on the formulation, and a deliquescent hydrate's on which hydrate it
+/// actually is. Guessing would be worse than declining: a wrong limit either blocks a tank that would have
+/// mixed or passes one that will not. A salt with no entry is reported in
+/// <see cref="ConcentratePlan.UnknownSolubility"/> rather than assumed to be fine, which is the whole
+/// reason <see cref="Limit"/> returns null instead of a default.
+/// </para>
+/// </remarks>
+public sealed class SolubilityTable
+{
+    private readonly Dictionary<string, double> _gramsPerLitre;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SolubilityTable"/> class.
+    /// </summary>
+    /// <param name="gramsPerLitreAt20C">
+    /// Solubility in grams per litre of water at 20 °C, keyed by fertilizer name. Names are matched
+    /// case-insensitively. Use <see cref="double.PositiveInfinity"/> for a salt that is miscible.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="gramsPerLitreAt20C"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when any value is zero, negative or NaN.</exception>
+    public SolubilityTable(IEnumerable<KeyValuePair<string, double>> gramsPerLitreAt20C)
+    {
+        ArgumentNullException.ThrowIfNull(gramsPerLitreAt20C);
+
+        _gramsPerLitre = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+
+        foreach ((string name, double limit) in gramsPerLitreAt20C)
+        {
+            if (double.IsNaN(limit) || limit <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(gramsPerLitreAt20C),
+                    limit,
+                    $"'{name}' has a solubility of {limit}, which is not a quantity that can dissolve.");
+            }
+
+            _gramsPerLitre[name] = limit;
+        }
+    }
+
+    /// <summary>
+    /// Gets the built-in table, covering the salts in the preset catalogue whose published figures agree.
+    /// </summary>
+    /// <remarks>
+    /// Values are the ordinary handbook solubilities at 20 °C for the hydrate the catalogue names. The two
+    /// worth knowing by heart are the low ones, because they are what a concentrate actually runs into:
+    /// monocalcium phosphate at 18 g/L and boric acid at 49 g/L will bind long before potassium nitrate's
+    /// 316 does.
+    /// </remarks>
+    public static SolubilityTable Default { get; } = new(new Dictionary<string, double>
+    {
+        // Macro salts.
+        ["Calcium Nitrate Tetrahydrate"] = 1290,
+        ["Potassium Nitrate"] = 316,
+        ["Magnesium Sulfate Heptahydrate (MGS)"] = 710,
+        ["Magnesium Nitrate Hexahydrate (MAG)"] = 1250,
+        ["Potassium Dihydrogen Phosphate (MKP)"] = 226,
+        ["Potassium Dibasic Phosphate"] = 1490,
+        ["Monoammonium Phosphate"] = 383,
+        ["Calcium Monobasic Phosphate"] = 18,
+        ["Potassium Sulfate (SOP)"] = 111,
+        ["Ammonium Sulfate"] = 754,
+        ["Ammonium Nitrate"] = 1500,
+        ["Ammonium Chloride"] = 372,
+        ["Potassium Chloride"] = 344,
+        ["Urea"] = 1080,
+        ["Phosphoric Acid"] = double.PositiveInfinity,
+
+        // Micro salts. Boric acid and borax matter most: they are barely soluble and boron is dosed high
+        // enough for the limit to bind at concentrate strength.
+        ["Boric Acid"] = 49,
+        ["Sodium Borate Decahydrate"] = 51,
+        ["Iron(II) Sulfate Heptahydrate"] = 256,
+        ["Copper Sulfate Pentahydrate"] = 320,
+        ["Zinc Sulfate Monohydrate"] = 600,
+        ["Sodium Molybdate Dihydrate"] = 840,
+    });
+
+    /// <summary>
+    /// Gets an empty table, for a caller who would rather supply every figure themselves.
+    /// </summary>
+    public static SolubilityTable Empty { get; } = new(new Dictionary<string, double>());
+
+    /// <summary>
+    /// Gets the number of salts the table knows about.
+    /// </summary>
+    public int Count => _gramsPerLitre.Count;
+
+    /// <summary>
+    /// Returns a copy of this table with one salt's limit added or replaced.
+    /// </summary>
+    /// <param name="fertilizerName">The fertilizer's name, matched case-insensitively.</param>
+    /// <param name="gramsPerLitreAt20C">
+    /// How much dissolves in a litre of water at 20 °C. A bag label or supplier datasheet is the right
+    /// source for a salt of your own.
+    /// </param>
+    /// <returns>A new table; this one is unchanged.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="fertilizerName"/> is null or blank.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="gramsPerLitreAt20C"/> is zero, negative or NaN.
+    /// </exception>
+    public SolubilityTable With(string fertilizerName, double gramsPerLitreAt20C)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fertilizerName);
+
+        Dictionary<string, double> merged = new(_gramsPerLitre, StringComparer.OrdinalIgnoreCase)
+        {
+            [fertilizerName] = gramsPerLitreAt20C
+        };
+
+        return new SolubilityTable(merged);
+    }
+
+    /// <summary>
+    /// Gets a salt's solubility, or null when the table has no figure for it.
+    /// </summary>
+    /// <param name="fertilizerName">The fertilizer's name, matched case-insensitively.</param>
+    /// <returns>Grams per litre at 20 °C, or null when unknown.</returns>
+    /// <remarks>
+    /// Null rather than a default, so that "we do not know" cannot be mistaken for "this is fine". A custom
+    /// salt gets null unless its author supplies a figure through <see cref="With"/>.
+    /// </remarks>
+    public double? Limit(string fertilizerName) =>
+        fertilizerName is not null && _gramsPerLitre.TryGetValue(fertilizerName, out double limit)
+            ? limit
+            : null;
+}

--- a/src/SYT.NPKTools/Internal/AtomicMasses.cs
+++ b/src/SYT.NPKTools/Internal/AtomicMasses.cs
@@ -1,0 +1,28 @@
+namespace SYT.NPKTools.Internal;
+
+/// <summary>
+/// Standard atomic weights in grams per mole, from the IUPAC 2021 table.
+/// </summary>
+/// <remarks>
+/// These convert ppm to millimoles per litre, and only the ratio matters, so the four significant
+/// figures given here are far finer than any scale a grower owns.
+/// </remarks>
+internal static class AtomicMasses
+{
+    public const double N = 14.007;
+    public const double P = 30.974;
+    public const double K = 39.098;
+    public const double Ca = 40.078;
+    public const double Mg = 24.305;
+    public const double S = 32.06;
+    public const double Fe = 55.845;
+    public const double Cu = 63.546;
+    public const double Mn = 54.938;
+    public const double Zn = 65.38;
+    public const double B = 10.81;
+    public const double Mo = 95.95;
+    public const double Cl = 35.45;
+    public const double Si = 28.085;
+    public const double Se = 78.971;
+    public const double Na = 22.990;
+}

--- a/src/SYT.NPKTools/Internal/Charges.cs
+++ b/src/SYT.NPKTools/Internal/Charges.cs
@@ -1,0 +1,27 @@
+namespace SYT.NPKTools.Internal;
+
+/// <summary>
+/// Charge per ion, for converting millimoles to milliequivalents.
+/// </summary>
+/// <remarks>
+/// These are the species actually present in a nutrient solution run between pH 5.5 and 6.5, not the
+/// element's possible oxidation states. Phosphorus is dihydrogen phosphate at one charge rather than the
+/// two its formula might suggest, because H₂PO₄⁻ dominates in that range; nitrogen appears twice with
+/// opposite signs because nitrate and ammonium are different ions; and urea has no entry because it is a
+/// neutral molecule.
+/// </remarks>
+internal static class Charges
+{
+    // Cations.
+    public const double Potassium = 1;
+    public const double Calcium = 2;
+    public const double Magnesium = 2;
+    public const double Ammonium = 1;
+    public const double Sodium = 1;
+
+    // Anions. The sign is carried by which total the value is added to, so these are magnitudes.
+    public const double Nitrate = 1;
+    public const double DihydrogenPhosphate = 1;
+    public const double Sulfate = 2;
+    public const double Chloride = 1;
+}

--- a/src/SYT.NPKTools/Internal/MolarConductivities.cs
+++ b/src/SYT.NPKTools/Internal/MolarConductivities.cs
@@ -1,0 +1,54 @@
+namespace SYT.NPKTools.Internal;
+
+/// <summary>
+/// Limiting molar conductivities at 25 °C, in S·cm² per mole of ion.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are per mole of the ion rather than per equivalent, so the divalent values already carry their
+/// two charges: sulfate's 160.0 is 2 × 80.0. Multiplying a concentration in mM by one of these gives
+/// µS/cm directly, which is what makes the summation in
+/// <see cref="Nutrients.ConductivityEstimate"/> come out in a meter's own unit without a scale factor.
+/// </para>
+/// <para>
+/// 25 °C is not an arbitrary choice: conductivity meters apply automatic temperature compensation and
+/// report as if at 25 °C, so a figure computed at 25 °C is directly comparable with a reading.
+/// </para>
+/// </remarks>
+internal static class MolarConductivities
+{
+    // Cations.
+    public const double Potassium = 73.5;
+    public const double Calcium = 119.0;
+    public const double Magnesium = 106.0;
+    public const double Ammonium = 73.5;
+    public const double Sodium = 50.1;
+
+    // Anions.
+    public const double Nitrate = 71.4;
+    public const double DihydrogenPhosphate = 36.0;
+    public const double Sulfate = 160.0;
+    public const double Chloride = 76.3;
+
+    /// <summary>
+    /// The coefficient in the Kohlrausch-form correction for ion-ion interaction.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A sum of limiting conductivities describes infinitely dilute water. In a real solution the ions
+    /// interfere with each other's movement, so the true conductivity is lower, and increasingly so with
+    /// ionic strength: the sum runs 1.9% high at 0.001 M, 6.1% at 0.01 M and 16.3% at 0.1 M. Kohlrausch's
+    /// square-root form captures that shape, and applying it as
+    /// <c>EC = ideal × (1 − k√I)</c> needs one coefficient.
+    /// </para>
+    /// <para>
+    /// This one comes from the certified KCl conductivity standards — 147, 1412 and 12,880 µS/cm at 25 °C
+    /// for 0.001, 0.01 and 0.1 M — which are the same reference solutions conductivity meters are
+    /// calibrated against. At 0.55 the model lands within 0.3% of the first two, which bracket the ionic
+    /// strength a nutrient solution actually has (0.01–0.04 M), and about 4% low at 0.1 M, an order of
+    /// magnitude stronger than any feed. It is a reference-anchored constant rather than a coefficient
+    /// fitted to fertilizer recipes.
+    /// </para>
+    /// </remarks>
+    public const double InteractionCoefficient = 0.55;
+}

--- a/src/SYT.NPKTools/Internal/MolarConductivities.cs
+++ b/src/SYT.NPKTools/Internal/MolarConductivities.cs
@@ -31,6 +31,17 @@ internal static class MolarConductivities
     public const double Chloride = 76.3;
 
     /// <summary>
+    /// Bicarbonate, HCO₃⁻.
+    /// </summary>
+    /// <remarks>
+    /// Not a plant nutrient, so it has no place in a <see cref="Nutrients.Ppm"/> profile — but it conducts,
+    /// and in ordinary tap water it carries most of the negative charge. Leaving it out understates the
+    /// conductivity of a moderately hard supply by around a quarter, which is why the conductivity estimate
+    /// takes it as a separate argument rather than pretending it is absent.
+    /// </remarks>
+    public const double Bicarbonate = 44.5;
+
+    /// <summary>
     /// The coefficient in the Kohlrausch-form correction for ion-ion interaction.
     /// </summary>
     /// <remarks>

--- a/src/SYT.NPKTools/NpkTools.cs
+++ b/src/SYT.NPKTools/NpkTools.cs
@@ -1,3 +1,4 @@
+using SYT.NPKTools.Fertilizers;
 using SYT.NPKTools.Nutrients;
 using SYT.NPKTools.Optimization;
 
@@ -77,4 +78,50 @@ public static class NpkTools
     /// </remarks>
     public static IFertilizerBundleRepository CreateBundleRepository() =>
         new FertilizerBundleRepository();
+
+    /// <summary>
+    /// Creates an optimization service that searches a person's own salts instead of the preset
+    /// catalogue.
+    /// </summary>
+    /// <param name="salts">
+    /// The salts on hand, in any order and any mix of macro and micro. Weights are irrelevant — the
+    /// optimizer computes them — so a salt need only carry its composition.
+    /// </param>
+    /// <param name="settings">
+    /// Bounds on how many bundles to generate from those salts. Defaults to
+    /// <see cref="BundleGenerationSettings.Default"/>.
+    /// </param>
+    /// <param name="solver">The linear solver to use. Defaults to <see cref="SimplexOptimizationSolver"/>.</param>
+    /// <returns>An <see cref="IFertilizerOptimizationService"/> over the supplied salts.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="salts"/> is null.</exception>
+    /// <remarks>
+    /// To see what generation left out — an element none of the salts supply, a salt that carries
+    /// nothing usable — construct <see cref="CustomFertilizerBundleRepository"/> directly and read its
+    /// properties, then pass it to <see cref="FertilizerOptimizationService"/>. This overload is for the
+    /// common case where the salts are known to be sufficient.
+    /// </remarks>
+    public static IFertilizerOptimizationService CreateOptimizationService(
+        IEnumerable<Fertilizer> salts,
+        BundleGenerationSettings? settings = null,
+        IOptimizationProblemSolver? solver = null) =>
+        new FertilizerOptimizationService(
+            CreateOptimizer(solver),
+            new CustomFertilizerBundleRepository(salts, settings));
+
+    /// <summary>
+    /// Creates a bundle repository over a person's own salts, generating the bundles from them.
+    /// </summary>
+    /// <param name="salts">The salts on hand.</param>
+    /// <param name="settings">
+    /// Bounds on how many bundles to generate. Defaults to <see cref="BundleGenerationSettings.Default"/>.
+    /// </param>
+    /// <returns>
+    /// The repository. Its concrete type is returned rather than the interface so that callers can read
+    /// what generation left out.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="salts"/> is null.</exception>
+    public static CustomFertilizerBundleRepository CreateBundleRepository(
+        IEnumerable<Fertilizer> salts,
+        BundleGenerationSettings? settings = null) =>
+        new(salts, settings);
 }

--- a/src/SYT.NPKTools/Nutrients/Builders/WaterProfileBuilder.cs
+++ b/src/SYT.NPKTools/Nutrients/Builders/WaterProfileBuilder.cs
@@ -1,0 +1,7 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// Fluent builder for <see cref="WaterProfile"/>. Each element may be set at most once.
+/// Elements left unset default to zero, so only name what your water analysis reports.
+/// </summary>
+public sealed class WaterProfileBuilder : WaterProfileBuilderBase<WaterProfileBuilder>;

--- a/src/SYT.NPKTools/Nutrients/Builders/WaterProfileBuilderBase.cs
+++ b/src/SYT.NPKTools/Nutrients/Builders/WaterProfileBuilderBase.cs
@@ -1,0 +1,61 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// Shared implementation behind <see cref="WaterProfileBuilder"/>, generic over the concrete builder
+/// type so that every <c>Add*</c> method returns the derived builder for chaining.
+/// </summary>
+/// <typeparam name="TBuilder">The concrete builder inheriting from this base class.</typeparam>
+/// <remarks>
+/// Every value defaults to zero, so you only name the elements your water report actually lists.
+/// </remarks>
+public class WaterProfileBuilderBase<TBuilder> : BuilderBase<TBuilder>
+    where TBuilder : WaterProfileBuilderBase<TBuilder>
+{
+    protected double Nitrate, Ammonium, Amine;
+    protected double P, K, Ca, Mg, S, Fe, Cu, Mn, Zn, B, Mo, Cl, Si, Se, Na;
+    protected override TBuilder Self => (TBuilder)this;
+
+    public override WaterProfile Build()
+    {
+        return new WaterProfile(
+            new NitrogenPpm(Nitrate, Ammonium, Amine),
+            new PhosphorusPpm(P),
+            new PotassiumPpm(K),
+            new CalciumPpm(Ca),
+            new MagnesiumPpm(Mg),
+            new SulfurPpm(S),
+            new IronPpm(Fe),
+            new CopperPpm(Cu),
+            new ManganesePpm(Mn),
+            new ZincPpm(Zn),
+            new BoronPpm(B),
+            new MolybdenumPpm(Mo),
+            new ChlorinePpm(Cl),
+            new SiliconPpm(Si),
+            new SeleniumPpm(Se),
+            new SodiumPpm(Na)
+        );
+    }
+
+    /// <summary>
+    /// Nitrate nitrogen (NO₃-N), the form a water analysis normally reports.
+    /// </summary>
+    public TBuilder AddNitrate(double value) => SetValue(ref Nitrate, value, nameof(Nitrate));
+    public TBuilder AddAmmonium(double value) => SetValue(ref Ammonium, value, nameof(Ammonium));
+    public TBuilder AddAmine(double value) => SetValue(ref Amine, value, nameof(Amine));
+    public TBuilder AddP(double value) => SetValue(ref P, value, nameof(P));
+    public TBuilder AddK(double value) => SetValue(ref K, value, nameof(K));
+    public TBuilder AddCa(double value) => SetValue(ref Ca, value, nameof(Ca));
+    public TBuilder AddMg(double value) => SetValue(ref Mg, value, nameof(Mg));
+    public TBuilder AddS(double value) => SetValue(ref S, value, nameof(S));
+    public TBuilder AddFe(double value) => SetValue(ref Fe, value, nameof(Fe));
+    public TBuilder AddCu(double value) => SetValue(ref Cu, value, nameof(Cu));
+    public TBuilder AddMn(double value) => SetValue(ref Mn, value, nameof(Mn));
+    public TBuilder AddZn(double value) => SetValue(ref Zn, value, nameof(Zn));
+    public TBuilder AddB(double value) => SetValue(ref B, value, nameof(B));
+    public TBuilder AddMo(double value) => SetValue(ref Mo, value, nameof(Mo));
+    public TBuilder AddCl(double value) => SetValue(ref Cl, value, nameof(Cl));
+    public TBuilder AddSi(double value) => SetValue(ref Si, value, nameof(Si));
+    public TBuilder AddSe(double value) => SetValue(ref Se, value, nameof(Se));
+    public TBuilder AddNa(double value) => SetValue(ref Na, value, nameof(Na));
+}

--- a/src/SYT.NPKTools/Nutrients/ConductivityEstimate.cs
+++ b/src/SYT.NPKTools/Nutrients/ConductivityEstimate.cs
@@ -49,9 +49,11 @@ public sealed record ConductivityEstimate
         double phosphate,
         double sulfate,
         double chloride,
+        double bicarbonate,
         double ionicStrength,
         double correction)
     {
+        Bicarbonate = bicarbonate;
         Potassium = potassium;
         Calcium = calcium;
         Magnesium = magnesium;
@@ -93,6 +95,16 @@ public sealed record ConductivityEstimate
     public double Chloride { get; }
 
     /// <summary>
+    /// Gets HCO₃⁻'s share of the ideal conductivity, in µS/cm. Zero unless bicarbonate was supplied.
+    /// </summary>
+    /// <remarks>
+    /// Bicarbonate is not a plant nutrient and so cannot live in a <see cref="Ppm"/> profile, but it conducts
+    /// and in ordinary tap water it carries most of the negative charge. Omitting it understates a moderately
+    /// hard supply by around a quarter.
+    /// </remarks>
+    public double Bicarbonate { get; }
+
+    /// <summary>
     /// Gets the solution's ionic strength in moles per litre, ½Σcz².
     /// </summary>
     /// <remarks>
@@ -116,7 +128,7 @@ public sealed record ConductivityEstimate
     /// </summary>
     public double IdealMicroSiemensPerCm =>
         Potassium + Calcium + Magnesium + Ammonium + Sodium
-        + Nitrate + Phosphate + Sulfate + Chloride;
+        + Nitrate + Phosphate + Sulfate + Chloride + Bicarbonate;
 
     /// <summary>
     /// Gets the estimated conductivity in µS/cm — the figure to compare with a meter.

--- a/src/SYT.NPKTools/Nutrients/ConductivityEstimate.cs
+++ b/src/SYT.NPKTools/Nutrients/ConductivityEstimate.cs
@@ -1,0 +1,153 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// An estimate of a solution's electrical conductivity, computed from its ions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// EC is what a grower actually measures, so being able to predict it is what connects a calculated recipe
+/// to the meter in the reservoir. It is computed here the way conductivity works — each ion's own molar
+/// conductivity times how much of it there is — rather than by scaling total dissolved solids by a fitted
+/// factor. That matters because the two are not interchangeable: a mole of sulfate conducts more than twice
+/// as much as a mole of dihydrogen phosphate, so two solutions of identical ppm can read differently, and a
+/// single factor cannot know which one it has been given.
+/// </para>
+/// <para>
+/// <b>How accurate.</b> <see cref="IdealMicroSiemensPerCm"/> is the sum of limiting molar conductivities,
+/// exact for infinitely dilute water and increasingly high above it, because ions interfere with each
+/// other's movement as they crowd. <see cref="MicroSiemensPerCm"/> applies a Kohlrausch-form correction for
+/// that, with its one coefficient taken from the certified KCl conductivity standards — the same solutions
+/// meters are calibrated against. Against those standards the corrected figure is within 0.3% at 0.001 M
+/// and 0.01 M, which bracket the ionic strength of a real feed.
+/// </para>
+/// <para>
+/// Expect to be within a few percent of a meter, not to replace it. The remaining error is not the model's
+/// alone: the source water's bicarbonate conducts and is not modelled here, meter calibration drifts, and
+/// temperature compensation is itself approximate.
+/// </para>
+/// <para>
+/// <b>What is left out.</b> The same ions <see cref="IonBalance"/> excludes, for the same reasons.
+/// Micronutrients are ambiguous in speciation and, at under 5 ppm in total, would add roughly 3 µS/cm to a
+/// figure around 2,000 — under 0.2%, and less than the meter's own tolerance. Urea and boric acid conduct
+/// nothing at all, being uncharged; a solution of urea alone reads as pure water on an EC meter while
+/// carrying a great deal of nitrogen, which is exactly why EC is a poor proxy for feed strength when urea
+/// is involved.
+/// </para>
+/// </remarks>
+public sealed record ConductivityEstimate
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConductivityEstimate"/> record.
+    /// </summary>
+    internal ConductivityEstimate(
+        double potassium,
+        double calcium,
+        double magnesium,
+        double ammonium,
+        double sodium,
+        double nitrate,
+        double phosphate,
+        double sulfate,
+        double chloride,
+        double ionicStrength,
+        double correction)
+    {
+        Potassium = potassium;
+        Calcium = calcium;
+        Magnesium = magnesium;
+        Ammonium = ammonium;
+        Sodium = sodium;
+        Nitrate = nitrate;
+        Phosphate = phosphate;
+        Sulfate = sulfate;
+        Chloride = chloride;
+        IonicStrength = ionicStrength;
+        Correction = correction;
+    }
+
+    /// <summary>Gets K⁺'s share of the ideal conductivity, in µS/cm.</summary>
+    public double Potassium { get; }
+
+    /// <summary>Gets Ca²⁺'s share of the ideal conductivity, in µS/cm.</summary>
+    public double Calcium { get; }
+
+    /// <summary>Gets Mg²⁺'s share of the ideal conductivity, in µS/cm.</summary>
+    public double Magnesium { get; }
+
+    /// <summary>Gets NH₄⁺'s share of the ideal conductivity, in µS/cm.</summary>
+    public double Ammonium { get; }
+
+    /// <summary>Gets Na⁺'s share of the ideal conductivity, in µS/cm.</summary>
+    public double Sodium { get; }
+
+    /// <summary>Gets NO₃⁻'s share of the ideal conductivity, in µS/cm.</summary>
+    public double Nitrate { get; }
+
+    /// <summary>Gets H₂PO₄⁻'s share of the ideal conductivity, in µS/cm.</summary>
+    public double Phosphate { get; }
+
+    /// <summary>Gets SO₄²⁻'s share of the ideal conductivity, in µS/cm.</summary>
+    public double Sulfate { get; }
+
+    /// <summary>Gets Cl⁻'s share of the ideal conductivity, in µS/cm.</summary>
+    public double Chloride { get; }
+
+    /// <summary>
+    /// Gets the solution's ionic strength in moles per litre, ½Σcz².
+    /// </summary>
+    /// <remarks>
+    /// Exactly computable, and the quantity that decides how far the ideal sum overshoots. A working feed
+    /// sits around 0.02–0.04; above about 0.05 the correction here is outside the range its coefficient was
+    /// anchored over.
+    /// </remarks>
+    public double IonicStrength { get; }
+
+    /// <summary>
+    /// Gets the factor applied to the ideal sum to account for ion-ion interaction, between 0 and 1.
+    /// </summary>
+    /// <remarks>
+    /// Exposed rather than hidden, because it is the one modelled quantity in the estimate. Around 0.91 for
+    /// a typical feed — that is, the ideal sum runs about 9% high before correction.
+    /// </remarks>
+    public double Correction { get; }
+
+    /// <summary>
+    /// Gets the conductivity ignoring ion-ion interaction, in µS/cm. An upper bound.
+    /// </summary>
+    public double IdealMicroSiemensPerCm =>
+        Potassium + Calcium + Magnesium + Ammonium + Sodium
+        + Nitrate + Phosphate + Sulfate + Chloride;
+
+    /// <summary>
+    /// Gets the estimated conductivity in µS/cm — the figure to compare with a meter.
+    /// </summary>
+    public double MicroSiemensPerCm => IdealMicroSiemensPerCm * Correction;
+
+    /// <summary>
+    /// Gets the estimated conductivity in mS/cm, the unit most meters display.
+    /// </summary>
+    public double MilliSiemensPerCm => MicroSiemensPerCm / 1000;
+
+    /// <summary>
+    /// Converts the estimate to the "ppm" figure a TDS meter shows.
+    /// </summary>
+    /// <param name="scale">
+    /// The conversion factor the meter uses. 500 is the NaCl scale used by Truncheon and Eutech meters; 700
+    /// is the KCl scale used by Hanna; 640 also appears. Defaults to 500.
+    /// </param>
+    /// <returns>The displayed TDS figure.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="scale"/> is not positive.</exception>
+    /// <remarks>
+    /// A TDS meter measures conductivity and multiplies. The scale is a convention rather than chemistry,
+    /// which is why it is a parameter and why two meters disagree by 40% on the same solution while both
+    /// being correct. This is also why the nutrient ppm elsewhere in this library — actual milligrams of an
+    /// element per litre — is a different quantity from a TDS meter's "ppm", and the two should never be
+    /// compared.
+    /// </remarks>
+    public double AsTdsPpm(double scale = 500)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(scale);
+
+        return MilliSiemensPerCm * scale;
+    }
+}

--- a/src/SYT.NPKTools/Nutrients/ConductivityEstimate.cs
+++ b/src/SYT.NPKTools/Nutrients/ConductivityEstimate.cs
@@ -119,9 +119,38 @@ public sealed record ConductivityEstimate
     /// </summary>
     /// <remarks>
     /// Exposed rather than hidden, because it is the one modelled quantity in the estimate. Around 0.91 for
-    /// a typical feed — that is, the ideal sum runs about 9% high before correction.
+    /// a typical feed — that is, the ideal sum runs about 9% high before correction. It stops changing above
+    /// <see cref="ValidatedIonicStrength"/>; see <see cref="IsWithinValidatedRange"/>.
     /// </remarks>
     public double Correction { get; }
+
+    /// <summary>
+    /// The ionic strength, in mol/L, up to which this estimate is anchored on certified reference solutions.
+    /// </summary>
+    /// <remarks>
+    /// The highest of the three KCl conductivity standards the correction is fitted against. A working
+    /// nutrient solution sits around 0.02–0.04, comfortably inside it.
+    /// </remarks>
+    public const double ValidatedIonicStrength = 0.1;
+
+    /// <summary>
+    /// Gets a value indicating whether the solution is dilute enough for this estimate to mean anything.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// False above <see cref="ValidatedIonicStrength"/>, where no simple model works and this one has no
+    /// reference solution to have been checked against. The figure is still monotonic there — more salt
+    /// always reads as more conductivity — but it runs increasingly high and should be treated as an
+    /// ordering, not a measurement.
+    /// </para>
+    /// <para>
+    /// The case that makes this worth checking is a concentrate. Reading the EC of a tank rather than of the
+    /// finished feed puts the ionic strength an order of magnitude past anything the model was anchored on: a
+    /// working solution at 1:100 lands near I = 2.5. There is no useful estimate to give there, so the honest
+    /// signal is this flag.
+    /// </para>
+    /// </remarks>
+    public bool IsWithinValidatedRange => IonicStrength <= ValidatedIonicStrength;
 
     /// <summary>
     /// Gets the conductivity ignoring ion-ion interaction, in µS/cm. An upper bound.

--- a/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
+++ b/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
@@ -1,4 +1,5 @@
 using SYT.NPKTools.Fertilizers;
+using SYT.NPKTools.Internal;
 
 namespace SYT.NPKTools.Nutrients;
 
@@ -14,6 +15,74 @@ public static class PpmExtensions
     /// <returns>The ratios, and the total concentration.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ppm"/> is null.</exception>
     public static NutrientRatios Ratios(this Ppm ppm) => new(ppm);
+
+    /// <summary>
+    /// Converts the profile to millimoles per litre, the unit the horticultural literature uses.
+    /// </summary>
+    /// <param name="ppm">The measured concentrations.</param>
+    /// <returns>The same profile in mM.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ppm"/> is null.</exception>
+    /// <remarks>
+    /// Ppm is a mass unit, so it flatters the light elements: 40 ppm of calcium and 40 ppm of magnesium
+    /// are 1.0 mM and 1.65 mM. Every published formulation — Steiner, Hoagland, the Dutch advisory tables
+    /// — is stated in mM for that reason.
+    /// </remarks>
+    public static MolarProfile AsMillimolar(this Ppm ppm)
+    {
+        ArgumentNullException.ThrowIfNull(ppm);
+
+        return new MolarProfile(
+            nitrate: ppm.Nitrogen.Nitrate / AtomicMasses.N,
+            ammonium: ppm.Nitrogen.Ammonium / AtomicMasses.N,
+            amine: ppm.Nitrogen.Amine / AtomicMasses.N,
+            phosphorus: ppm.Phosphorus.Value / AtomicMasses.P,
+            potassium: ppm.Potassium.Value / AtomicMasses.K,
+            calcium: ppm.Calcium.Value / AtomicMasses.Ca,
+            magnesium: ppm.Magnesium.Value / AtomicMasses.Mg,
+            sulfur: ppm.Sulfur.Value / AtomicMasses.S,
+            iron: ppm.Iron.Value / AtomicMasses.Fe,
+            copper: ppm.Copper.Value / AtomicMasses.Cu,
+            manganese: ppm.Manganese.Value / AtomicMasses.Mn,
+            zinc: ppm.Zinc.Value / AtomicMasses.Zn,
+            boron: ppm.Boron.Value / AtomicMasses.B,
+            molybdenum: ppm.Molybdenum.Value / AtomicMasses.Mo,
+            chlorine: ppm.Chlorine.Value / AtomicMasses.Cl,
+            silicon: ppm.Silicon.Value / AtomicMasses.Si,
+            selenium: ppm.Selenium.Value / AtomicMasses.Se,
+            sodium: ppm.Sodium.Value / AtomicMasses.Na);
+    }
+
+    /// <summary>
+    /// Expresses the profile as charge, in milliequivalents per litre, and reports whether it balances.
+    /// </summary>
+    /// <param name="ppm">The measured concentrations.</param>
+    /// <returns>The cations, the anions and the difference between them.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ppm"/> is null.</exception>
+    /// <remarks>
+    /// A recipe made only of salts balances exactly, because every salt is electrically neutral. Where it
+    /// does not, the gap is the acid or base the recipe itself contributes — phosphoric acid releases a
+    /// proton per phosphorus, dipotassium phosphate consumes one — so
+    /// <see cref="Nutrients.IonBalance.AcidEquivalents"/> measures how much acidity the recipe adds to the
+    /// water before any pH adjustment. See <see cref="IonBalance"/> for what is counted and what is
+    /// deliberately left out.
+    /// </remarks>
+    public static IonBalance IonBalance(this Ppm ppm)
+    {
+        ArgumentNullException.ThrowIfNull(ppm);
+
+        MolarProfile mM = ppm.AsMillimolar();
+
+        return new IonBalance(
+            potassium: mM.Potassium * Charges.Potassium,
+            calcium: mM.Calcium * Charges.Calcium,
+            magnesium: mM.Magnesium * Charges.Magnesium,
+            ammonium: mM.Ammonium * Charges.Ammonium,
+            sodium: mM.Sodium * Charges.Sodium,
+            nitrate: mM.Nitrate * Charges.Nitrate,
+            phosphate: mM.Phosphorus * Charges.DihydrogenPhosphate,
+            sulfate: mM.Sulfur * Charges.Sulfate,
+            chloride: mM.Chlorine * Charges.Chloride);
+    }
 
     /// <summary>
     /// Breaks a mix down into what each fertilizer in it contributes.

--- a/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
+++ b/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
@@ -88,6 +88,14 @@ public static class PpmExtensions
     /// Estimates the electrical conductivity a meter would read for this solution.
     /// </summary>
     /// <param name="ppm">The measured concentrations.</param>
+    /// <param name="bicarbonateMeqPerLitre">
+    /// Bicarbonate present in the solution, in meq/L. Defaults to zero, which is right for a mix of salts in
+    /// pure water. For tap water it is not: bicarbonate carries most of the negative charge in a hard supply
+    /// and omitting it reads about a quarter low, so pass
+    /// <see cref="WaterProfileExtensions.EstimatedAlkalinity"/> when the source water is in the profile. It is
+    /// an argument rather than a field because HCO₃⁻ is not a plant nutrient and has no place in a
+    /// <see cref="Ppm"/>.
+    /// </param>
     /// <returns>The estimate, its ideal upper bound, and each ion's share.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ppm"/> is null.</exception>
     /// <remarks>
@@ -96,16 +104,21 @@ public static class PpmExtensions
     /// identical ppm can read differently, and a single factor cannot tell which it was given. See
     /// <see cref="ConductivityEstimate"/> for the accuracy and what is excluded.
     /// </remarks>
-    public static ConductivityEstimate EstimateConductivity(this Ppm ppm)
+    public static ConductivityEstimate EstimateConductivity(
+        this Ppm ppm,
+        double bicarbonateMeqPerLitre = 0)
     {
         ArgumentNullException.ThrowIfNull(ppm);
+        ArgumentOutOfRangeException.ThrowIfNegative(bicarbonateMeqPerLitre);
 
         MolarProfile mM = ppm.AsMillimolar();
 
         // Ionic strength is half the sum of cz², in moles per litre. The mM figures are divided by 1000 to
         // get there, and the divalent ions contribute four times their concentration.
+        // Bicarbonate is monovalent, so its meq/L and mmol/L are the same number.
         double ionicStrength = (
             mM.Potassium + mM.Ammonium + mM.Sodium + mM.Nitrate + mM.Phosphorus + mM.Chlorine
+            + bicarbonateMeqPerLitre
             + 4 * (mM.Calcium + mM.Magnesium + mM.Sulfur)) / 2000;
 
         double correction = Math.Max(
@@ -122,8 +135,61 @@ public static class PpmExtensions
             phosphate: mM.Phosphorus * MolarConductivities.DihydrogenPhosphate,
             sulfate: mM.Sulfur * MolarConductivities.Sulfate,
             chloride: mM.Chlorine * MolarConductivities.Chloride,
+            bicarbonate: bicarbonateMeqPerLitre * MolarConductivities.Bicarbonate,
             ionicStrength: ionicStrength,
             correction: correction);
+    }
+
+    /// <summary>
+    /// Adds a source water's own nutrients to a mix's, giving what is actually in the reservoir.
+    /// </summary>
+    /// <param name="solution">The concentrations the fertilizers supply.</param>
+    /// <param name="water">The source water's analysis.</param>
+    /// <returns>The combined profile.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="solution"/> or <paramref name="water"/> is null.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Every analysis in this library — the ratios, mM, the charge balance, EC — describes the profile it is
+    /// given. Hand a mix's own ppm to any of them and the answer omits the water, which for calcium in a hard
+    /// supply can be a third of what is really there. This is the step that composes the two, and it exists
+    /// because composing them by hand is easy to get wrong: it is a nutrient at a time, and forgetting that
+    /// nitrogen has three forms drops the ammonium silently.
+    /// </para>
+    /// <para>
+    /// Bicarbonate is not carried, having no place in a <see cref="Ppm"/>. For the reservoir's conductivity,
+    /// pass the water's alkalinity alongside:
+    /// <c>mix.Plus(water).EstimateConductivity(water.EstimatedAlkalinity())</c>. Acidifying the reservoir
+    /// removes some of that bicarbonate and with it some of the EC, which this does not model.
+    /// </para>
+    /// </remarks>
+    public static Ppm Plus(this Ppm solution, WaterProfile water)
+    {
+        ArgumentNullException.ThrowIfNull(solution);
+        ArgumentNullException.ThrowIfNull(water);
+
+        return new PpmBuilder()
+            .AddNitrate(solution.Nitrogen.Nitrate + water.Nitrogen.Nitrate)
+            .AddAmmonium(solution.Nitrogen.Ammonium + water.Nitrogen.Ammonium)
+            .AddAmine(solution.Nitrogen.Amine + water.Nitrogen.Amine)
+            .AddP(solution.Phosphorus.Value + water.Phosphorus.Value)
+            .AddK(solution.Potassium.Value + water.Potassium.Value)
+            .AddCa(solution.Calcium.Value + water.Calcium.Value)
+            .AddMg(solution.Magnesium.Value + water.Magnesium.Value)
+            .AddS(solution.Sulfur.Value + water.Sulfur.Value)
+            .AddFe(solution.Iron.Value + water.Iron.Value)
+            .AddCu(solution.Copper.Value + water.Copper.Value)
+            .AddMn(solution.Manganese.Value + water.Manganese.Value)
+            .AddZn(solution.Zinc.Value + water.Zinc.Value)
+            .AddB(solution.Boron.Value + water.Boron.Value)
+            .AddMo(solution.Molybdenum.Value + water.Molybdenum.Value)
+            .AddCl(solution.Chlorine.Value + water.Chlorine.Value)
+            .AddSi(solution.Silicon.Value + water.Silicon.Value)
+            .AddSe(solution.Selenium.Value + water.Selenium.Value)
+            .AddNa(solution.Sodium.Value + water.Sodium.Value)
+            .AddLiters(solution.Liters.Value)
+            .Build();
     }
 
     /// <summary>

--- a/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
+++ b/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
@@ -85,6 +85,48 @@ public static class PpmExtensions
     }
 
     /// <summary>
+    /// Estimates the electrical conductivity a meter would read for this solution.
+    /// </summary>
+    /// <param name="ppm">The measured concentrations.</param>
+    /// <returns>The estimate, its ideal upper bound, and each ion's share.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ppm"/> is null.</exception>
+    /// <remarks>
+    /// Computed from each ion's own molar conductivity rather than by scaling total dissolved solids, because
+    /// a mole of sulfate conducts more than twice what a mole of dihydrogen phosphate does — two solutions of
+    /// identical ppm can read differently, and a single factor cannot tell which it was given. See
+    /// <see cref="ConductivityEstimate"/> for the accuracy and what is excluded.
+    /// </remarks>
+    public static ConductivityEstimate EstimateConductivity(this Ppm ppm)
+    {
+        ArgumentNullException.ThrowIfNull(ppm);
+
+        MolarProfile mM = ppm.AsMillimolar();
+
+        // Ionic strength is half the sum of cz², in moles per litre. The mM figures are divided by 1000 to
+        // get there, and the divalent ions contribute four times their concentration.
+        double ionicStrength = (
+            mM.Potassium + mM.Ammonium + mM.Sodium + mM.Nitrate + mM.Phosphorus + mM.Chlorine
+            + 4 * (mM.Calcium + mM.Magnesium + mM.Sulfur)) / 2000;
+
+        double correction = Math.Max(
+            0,
+            1 - MolarConductivities.InteractionCoefficient * Math.Sqrt(ionicStrength));
+
+        return new ConductivityEstimate(
+            potassium: mM.Potassium * MolarConductivities.Potassium,
+            calcium: mM.Calcium * MolarConductivities.Calcium,
+            magnesium: mM.Magnesium * MolarConductivities.Magnesium,
+            ammonium: mM.Ammonium * MolarConductivities.Ammonium,
+            sodium: mM.Sodium * MolarConductivities.Sodium,
+            nitrate: mM.Nitrate * MolarConductivities.Nitrate,
+            phosphate: mM.Phosphorus * MolarConductivities.DihydrogenPhosphate,
+            sulfate: mM.Sulfur * MolarConductivities.Sulfate,
+            chloride: mM.Chlorine * MolarConductivities.Chloride,
+            ionicStrength: ionicStrength,
+            correction: correction);
+    }
+
+    /// <summary>
     /// Breaks a mix down into what each fertilizer in it contributes.
     /// </summary>
     /// <param name="solution">The mix, as returned by the optimizer.</param>

--- a/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
+++ b/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
@@ -1,0 +1,52 @@
+using SYT.NPKTools.Fertilizers;
+
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// Analysis of a finished solution: the ratios that characterise it, and which fertilizer supplied what.
+/// </summary>
+public static class PpmExtensions
+{
+    /// <summary>
+    /// Describes the solution by the ratios between its nutrients rather than their absolute amounts.
+    /// </summary>
+    /// <param name="ppm">The measured concentrations.</param>
+    /// <returns>The ratios, and the total concentration.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ppm"/> is null.</exception>
+    public static NutrientRatios Ratios(this Ppm ppm) => new(ppm);
+
+    /// <summary>
+    /// Breaks a mix down into what each fertilizer in it contributes.
+    /// </summary>
+    /// <param name="solution">The mix, as returned by the optimizer.</param>
+    /// <param name="calculator">The ppm calculator to measure each fertilizer with.</param>
+    /// <returns>
+    /// One entry per fertilizer, in the mix's own order. Summing the entries reproduces the mix's total
+    /// concentrations, because each is measured against the same water volume.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="solution"/> or <paramref name="calculator"/> is null.
+    /// </exception>
+    /// <remarks>
+    /// Measured through the same calculator as the whole mix rather than by separate arithmetic, so the
+    /// parts cannot drift from the total.
+    /// </remarks>
+    public static IReadOnlyList<FertilizerContribution> Breakdown(
+        this Solution solution,
+        IPpmCalculationService calculator)
+    {
+        ArgumentNullException.ThrowIfNull(solution);
+        ArgumentNullException.ThrowIfNull(calculator);
+
+        List<FertilizerContribution> contributions = new(solution.Count);
+
+        foreach (Fertilizer fertilizer in solution)
+        {
+            contributions.Add(new FertilizerContribution(
+                fertilizer,
+                calculator.CalculatePpm([fertilizer], solution.WaterLiters)));
+        }
+
+        return contributions;
+    }
+}

--- a/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
+++ b/src/SYT.NPKTools/Nutrients/Extensions/PpmExtensions.cs
@@ -121,9 +121,15 @@ public static class PpmExtensions
             + bicarbonateMeqPerLitre
             + 4 * (mM.Calcium + mM.Magnesium + mM.Sulfur)) / 2000;
 
-        double correction = Math.Max(
-            0,
-            1 - MolarConductivities.InteractionCoefficient * Math.Sqrt(ionicStrength));
+        // The correction is anchored on KCl standards up to 0.1 M and the square-root form only holds while
+        // the solution is dilute. Left unclamped it keeps growing: it turns the estimate downwards past
+        // I ≈ 1.1 and reaches exactly zero at I ≈ 3.3, so a concentrate tank — a working feed at 1:100 sits
+        // near I = 2.5 — would report less conductivity the more salt it held, and eventually none. Freezing
+        // the correction at the top of the anchored range keeps the figure monotonic and non-zero; it is
+        // then too high rather than absurd, and IsWithinValidatedRange says not to trust it.
+        double correctionStrength = Math.Min(ionicStrength, ConductivityEstimate.ValidatedIonicStrength);
+        double correction =
+            1 - MolarConductivities.InteractionCoefficient * Math.Sqrt(correctionStrength);
 
         return new ConductivityEstimate(
             potassium: mM.Potassium * MolarConductivities.Potassium,

--- a/src/SYT.NPKTools/Nutrients/Extensions/PpmTargetExtensions.cs
+++ b/src/SYT.NPKTools/Nutrients/Extensions/PpmTargetExtensions.cs
@@ -1,0 +1,111 @@
+using SYT.NPKTools.Internal;
+
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// Operations on <see cref="PpmTarget"/> that account for what the source water already contains.
+/// </summary>
+public static class PpmTargetExtensions
+{
+    /// <summary>
+    /// Deducts what the source water already supplies, producing the target the fertilizers must
+    /// actually meet.
+    /// </summary>
+    /// <param name="target">The nutrient profile you want in the finished solution.</param>
+    /// <param name="water">
+    /// What the source water contains. Use <see cref="WaterProfile.Pure"/> for reverse osmosis or
+    /// distilled water, which leaves the target unchanged.
+    /// </param>
+    /// <returns>
+    /// The adjusted target, together with any elements the water oversupplies. Pass
+    /// <see cref="WaterAdjustedTarget.Target"/> to the optimizer.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="target"/> or <paramref name="water"/> is null.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Skipping this step is the most common way to get a mix that is right on paper and wrong in the
+    /// tank. Municipal water routinely carries tens of ppm of calcium, magnesium and sulfur; whatever it
+    /// carries is added on top of everything the fertilizers contribute.
+    /// </para>
+    /// <para>
+    /// An element the water already oversupplies is clamped to zero and reported in
+    /// <see cref="WaterAdjustedTarget.Excesses"/> rather than silently truncated, because the caller
+    /// needs to know: fertilizer only adds, so that element will overshoot no matter what is mixed.
+    /// </para>
+    /// <para>
+    /// The water volume comes from <paramref name="target"/> and is carried through untouched — a water
+    /// analysis is a concentration and does not depend on how much water is used.
+    /// </para>
+    /// </remarks>
+    public static WaterAdjustedTarget AdjustFor(this PpmTarget target, WaterProfile water)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(water);
+
+        List<NutrientExcess> excesses = [];
+
+        double n = Deduct(Names.N, target.N.Value, water.Nitrogen.Value, excesses);
+        double p = Deduct(Names.P, target.P.Value, water.Phosphorus.Value, excesses);
+        double k = Deduct(Names.K, target.K.Value, water.Potassium.Value, excesses);
+        double ca = Deduct(Names.Ca, target.Ca.Value, water.Calcium.Value, excesses);
+        double mg = Deduct(Names.Mg, target.Mg.Value, water.Magnesium.Value, excesses);
+        double s = Deduct(Names.S, target.S.Value, water.Sulfur.Value, excesses);
+        double fe = Deduct(Names.Fe, target.Fe.Value, water.Iron.Value, excesses);
+        double cu = Deduct(Names.Cu, target.Cu.Value, water.Copper.Value, excesses);
+        double mn = Deduct(Names.Mn, target.Mn.Value, water.Manganese.Value, excesses);
+        double zn = Deduct(Names.Zn, target.Zn.Value, water.Zinc.Value, excesses);
+        double b = Deduct(Names.B, target.B.Value, water.Boron.Value, excesses);
+        double mo = Deduct(Names.Mo, target.Mo.Value, water.Molybdenum.Value, excesses);
+        double cl = Deduct(Names.Cl, target.Cl.Value, water.Chlorine.Value, excesses);
+        double si = Deduct(Names.Si, target.Si.Value, water.Silicon.Value, excesses);
+        double se = Deduct(Names.Se, target.Se.Value, water.Selenium.Value, excesses);
+        double na = Deduct(Names.Na, target.Na.Value, water.Sodium.Value, excesses);
+
+        PpmTarget adjusted = new PpmTargetBuilder()
+            .AddN(n)
+            .AddP(p)
+            .AddK(k)
+            .AddCa(ca)
+            .AddMg(mg)
+            .AddS(s)
+            .AddFe(fe)
+            .AddCu(cu)
+            .AddMn(mn)
+            .AddZn(zn)
+            .AddB(b)
+            .AddMo(mo)
+            .AddCl(cl)
+            .AddSi(si)
+            .AddSe(se)
+            .AddNa(na)
+            .AddLiters(target.Liters.Value)
+            .Build();
+
+        return new WaterAdjustedTarget(adjusted, excesses);
+    }
+
+    /// <summary>
+    /// Subtracts the water's contribution from one element, recording an excess when the water supplies
+    /// more than was asked for.
+    /// </summary>
+    private static double Deduct(string element, double target, double inWater, List<NutrientExcess> excesses)
+    {
+        double remaining = target - inWater;
+
+        if (remaining >= 0)
+        {
+            return remaining;
+        }
+
+        // Only worth reporting when something was actually asked for. Water carrying sodium against a
+        // target that never mentioned sodium is normal and not the caller's problem to solve.
+        if (target > 0)
+        {
+            excesses.Add(new NutrientExcess(element, inWater, target));
+        }
+
+        return 0;
+    }
+}

--- a/src/SYT.NPKTools/Nutrients/Extensions/WaterProfileExtensions.cs
+++ b/src/SYT.NPKTools/Nutrients/Extensions/WaterProfileExtensions.cs
@@ -88,4 +88,30 @@ public static class WaterProfileExtensions
 
         return Math.Max(0, -balance.AcidEquivalents);
     }
+
+    /// <summary>
+    /// Estimates the conductivity of the source water itself, bicarbonate included.
+    /// </summary>
+    /// <param name="water">The source water's analysis.</param>
+    /// <returns>The estimate, comparable directly with a meter reading of the untreated water.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="water"/> is null.</exception>
+    /// <remarks>
+    /// <para>
+    /// Prefer this over <c>water.AsPpm().EstimateConductivity()</c>, which leaves bicarbonate out and so reads
+    /// about a quarter low on a moderately hard supply — 358 µS/cm against the roughly 456 a meter would show.
+    /// The bicarbonate comes from <see cref="EstimatedAlkalinity"/>, and inferring it is only defensible here:
+    /// in a water analysis the cation surplus is the alkalinity, whereas in a recipe the same gap is the
+    /// acid-base character of the salts and has nothing to do with bicarbonate.
+    /// </para>
+    /// <para>
+    /// This is the quickest check that an analysis was entered correctly — compare it against the meter
+    /// reading the grower already has for their tap.
+    /// </para>
+    /// </remarks>
+    public static ConductivityEstimate EstimateConductivity(this WaterProfile water)
+    {
+        ArgumentNullException.ThrowIfNull(water);
+
+        return water.AsPpm().EstimateConductivity(water.EstimatedAlkalinity());
+    }
 }

--- a/src/SYT.NPKTools/Nutrients/Extensions/WaterProfileExtensions.cs
+++ b/src/SYT.NPKTools/Nutrients/Extensions/WaterProfileExtensions.cs
@@ -98,7 +98,7 @@ public static class WaterProfileExtensions
     /// <remarks>
     /// <para>
     /// Prefer this over <c>water.AsPpm().EstimateConductivity()</c>, which leaves bicarbonate out and so reads
-    /// about a quarter low on a moderately hard supply — 358 µS/cm against the roughly 456 a meter would show.
+    /// about a quarter low on a moderately hard supply — 358 µS/cm against the roughly 454 a meter would show.
     /// The bicarbonate comes from <see cref="EstimatedAlkalinity"/>, and inferring it is only defensible here:
     /// in a water analysis the cation surplus is the alkalinity, whereas in a recipe the same gap is the
     /// acid-base character of the salts and has nothing to do with bicarbonate.

--- a/src/SYT.NPKTools/Nutrients/Extensions/WaterProfileExtensions.cs
+++ b/src/SYT.NPKTools/Nutrients/Extensions/WaterProfileExtensions.cs
@@ -1,0 +1,91 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// Reading a source-water analysis with the same tools as a finished solution.
+/// </summary>
+public static class WaterProfileExtensions
+{
+    /// <summary>
+    /// Expresses a water analysis as a <see cref="Ppm"/>, so the solution analyses apply to it.
+    /// </summary>
+    /// <param name="water">The source water's analysis.</param>
+    /// <param name="liters">
+    /// A nominal volume. A water analysis is a concentration and holds regardless of how much is used, so
+    /// this changes nothing the analyses read — it exists only because <see cref="Ppm"/> carries a volume.
+    /// </param>
+    /// <returns>The same concentrations as a ppm profile.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="water"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="liters"/> is not positive.</exception>
+    /// <remarks>
+    /// <para>
+    /// Worth doing for two readings in particular. <see cref="PpmExtensions.EstimateConductivity"/> gives the
+    /// EC of the water alone, which is directly comparable with the meter reading a grower already has and is
+    /// the quickest check that an analysis was entered correctly.
+    /// </para>
+    /// <para>
+    /// <see cref="PpmExtensions.IonBalance"/> measures something a finished recipe's balance does not. Real
+    /// water is electrically neutral, but the ion that usually balances it — bicarbonate — is not one of the
+    /// sixteen nutrients and so has nowhere to be entered. Whatever cation surplus an analysis shows is
+    /// therefore its alkalinity, in meq/L, which is also the acid needed per litre to neutralise it.
+    /// </para>
+    /// </remarks>
+    public static Ppm AsPpm(this WaterProfile water, double liters = 1)
+    {
+        ArgumentNullException.ThrowIfNull(water);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(liters);
+
+        return new PpmBuilder()
+            .AddNitrate(water.Nitrogen.Nitrate)
+            .AddAmmonium(water.Nitrogen.Ammonium)
+            .AddAmine(water.Nitrogen.Amine)
+            .AddP(water.Phosphorus.Value)
+            .AddK(water.Potassium.Value)
+            .AddCa(water.Calcium.Value)
+            .AddMg(water.Magnesium.Value)
+            .AddS(water.Sulfur.Value)
+            .AddFe(water.Iron.Value)
+            .AddCu(water.Copper.Value)
+            .AddMn(water.Manganese.Value)
+            .AddZn(water.Zinc.Value)
+            .AddB(water.Boron.Value)
+            .AddMo(water.Molybdenum.Value)
+            .AddCl(water.Chlorine.Value)
+            .AddSi(water.Silicon.Value)
+            .AddSe(water.Selenium.Value)
+            .AddNa(water.Sodium.Value)
+            .AddLiters(liters)
+            .Build();
+    }
+
+    /// <summary>
+    /// Estimates the water's alkalinity from its cation-anion gap, in meq/L.
+    /// </summary>
+    /// <param name="water">The source water's analysis.</param>
+    /// <returns>
+    /// The bicarbonate implied by the analysis, in meq/L, or zero when the analysis shows no cation surplus.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="water"/> is null.</exception>
+    /// <remarks>
+    /// <para>
+    /// Water is electrically neutral, so the cations in an analysis must be matched by anions. Bicarbonate is
+    /// usually what matches them, and it is not a plant nutrient, so it has nowhere to be entered — which
+    /// means the gap left over is a measurement of it rather than an error in the analysis. That gap is also
+    /// the acid required per litre to neutralise the water, which is what makes it worth surfacing: hard water
+    /// pushes the root-zone pH up all season if it is not accounted for.
+    /// </para>
+    /// <para>
+    /// An estimate from what the analysis contains, not a substitute for a measured alkalinity figure. It
+    /// assumes the analysis is complete for the ions it does cover, and it cannot distinguish bicarbonate from
+    /// carbonate or from an ion nobody entered. Multiply by 61 for ppm of HCO₃⁻, or by 50 for ppm as CaCO₃,
+    /// the form most water reports use.
+    /// </para>
+    /// </remarks>
+    public static double EstimatedAlkalinity(this WaterProfile water)
+    {
+        ArgumentNullException.ThrowIfNull(water);
+
+        IonBalance balance = water.AsPpm().IonBalance();
+
+        return Math.Max(0, -balance.AcidEquivalents);
+    }
+}

--- a/src/SYT.NPKTools/Nutrients/FertilizerContribution.cs
+++ b/src/SYT.NPKTools/Nutrients/FertilizerContribution.cs
@@ -1,0 +1,18 @@
+using SYT.NPKTools.Fertilizers;
+
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// What one fertilizer in a mix contributes to the finished solution.
+/// </summary>
+/// <param name="Fertilizer">The fertilizer, carrying the weight prescribed for it.</param>
+/// <param name="Contribution">
+/// The concentrations this fertilizer alone produces, in the same volume of water as the whole mix.
+/// </param>
+/// <remarks>
+/// Answers the question a bare recipe cannot: which salt is responsible for the sulfur you did not ask
+/// for. Every salt brings a counter-ion along with the nutrient you wanted, so an unwanted element is
+/// almost never a mistake in the mix — it is the price of the element next to it. Seeing which salt
+/// carries it is what makes a recipe adjustable rather than merely acceptable.
+/// </remarks>
+public sealed record FertilizerContribution(Fertilizer Fertilizer, Ppm Contribution);

--- a/src/SYT.NPKTools/Nutrients/IonBalance.cs
+++ b/src/SYT.NPKTools/Nutrients/IonBalance.cs
@@ -1,0 +1,149 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// The charge a solution carries, in milliequivalents per litre (meq/L), split into cations and anions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Milliequivalents are millimoles times charge, and they are how a solution's ionic strength and balance
+/// are read: 1 mM of calcium is 2 meq because Ca²⁺ carries two charges, while 1 mM of potassium is 1 meq.
+/// Formulation tables in the literature quote both.
+/// </para>
+/// <para>
+/// <b>What the difference between the two sides means.</b> Not an error. Every salt is electrically
+/// neutral, so a recipe of nothing but salts comes out exactly balanced — and where it does not, the gap
+/// is the acid or base the recipe itself contributes. Phosphoric acid supplies H₂PO₄⁻ with a proton
+/// rather than a metal, so it shows an anion surplus of one per phosphorus: that is the H⁺ it releases.
+/// Dipotassium phosphate is the mirror image, supplying two K⁺ against an HPO₄²⁻ that takes up a proton
+/// on its way to H₂PO₄⁻ at working pH, so it shows a cation surplus of one per phosphorus: that is the H⁺
+/// it consumes. <see cref="AcidEquivalents"/> is therefore a real measurement — how much acidity the
+/// recipe adds to or removes from the water, before any pH adjustment.
+/// </para>
+/// <para>
+/// Measured across the built-in catalogue, fourteen of the seventeen macro salts balance to zero. The
+/// three that do not are exactly the three with acid-base character: phosphoric acid and urea phosphate
+/// on the acid side, dipotassium phosphate on the basic side.
+/// </para>
+/// <para>
+/// <b>What is deliberately left out.</b> Micronutrients are not counted. Their speciation is genuinely
+/// ambiguous — iron may be Fe²⁺ or Fe³⁺, and in chelated form the complex is an anion rather than a
+/// cation — and at under 5 ppm in total they would move the balance by well under 0.1 meq/L against a
+/// typical 25–30. Guessing a charge for them would add uncertainty to a figure whose worth is that it is
+/// exact. Boron and silicon are excluded for a firmer reason: as boric and silicic acid they are
+/// undissociated at nutrient-solution pH and carry no charge at all. Urea is likewise absent — it is a
+/// neutral molecule, which is also why it contributes nothing to a plant's cation-anion uptake balance
+/// even though it contributes nitrogen.
+/// </para>
+/// <para>
+/// Phosphorus is counted as H₂PO₄⁻ at one charge, the dominant species between pH 5.5 and 6.5 where these
+/// solutions are run. Above pH 7.2 half of it is HPO₄²⁻ and the phosphate figure would be nearer 1.5
+/// charges. This library does not model pH, so the assumption is stated rather than computed — and it is
+/// the assumption that makes the acid-base reading above come out in whole protons.
+/// </para>
+/// </remarks>
+public sealed record IonBalance
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IonBalance"/> record.
+    /// </summary>
+    internal IonBalance(
+        double potassium,
+        double calcium,
+        double magnesium,
+        double ammonium,
+        double sodium,
+        double nitrate,
+        double phosphate,
+        double sulfate,
+        double chloride)
+    {
+        Potassium = potassium;
+        Calcium = calcium;
+        Magnesium = magnesium;
+        Ammonium = ammonium;
+        Sodium = sodium;
+        Nitrate = nitrate;
+        Phosphate = phosphate;
+        Sulfate = sulfate;
+        Chloride = chloride;
+    }
+
+    /// <summary>Gets K⁺ in meq/L.</summary>
+    public double Potassium { get; }
+
+    /// <summary>Gets Ca²⁺ in meq/L.</summary>
+    public double Calcium { get; }
+
+    /// <summary>Gets Mg²⁺ in meq/L.</summary>
+    public double Magnesium { get; }
+
+    /// <summary>Gets NH₄⁺ in meq/L.</summary>
+    public double Ammonium { get; }
+
+    /// <summary>Gets Na⁺ in meq/L.</summary>
+    public double Sodium { get; }
+
+    /// <summary>Gets NO₃⁻ in meq/L.</summary>
+    public double Nitrate { get; }
+
+    /// <summary>Gets H₂PO₄⁻ in meq/L.</summary>
+    public double Phosphate { get; }
+
+    /// <summary>Gets SO₄²⁻ in meq/L.</summary>
+    public double Sulfate { get; }
+
+    /// <summary>Gets Cl⁻ in meq/L.</summary>
+    public double Chloride { get; }
+
+    /// <summary>
+    /// Gets the total positive charge in meq/L.
+    /// </summary>
+    public double Cations => Potassium + Calcium + Magnesium + Ammonium + Sodium;
+
+    /// <summary>
+    /// Gets the total negative charge in meq/L.
+    /// </summary>
+    public double Anions => Nitrate + Phosphate + Sulfate + Chloride;
+
+    /// <summary>
+    /// Gets the total charge either way, in meq/L — a reasonable proxy for ionic strength, and the
+    /// quantity electrical conductivity tracks.
+    /// </summary>
+    public double Total => Cations + Anions;
+
+    /// <summary>
+    /// Gets the acidity the recipe itself contributes, in meq/L of H⁺.
+    /// </summary>
+    /// <remarks>
+    /// Positive means the recipe releases protons and pulls pH down, so less pH-down is needed than the
+    /// water's alkalinity alone would suggest. Negative means it consumes them and pushes pH up. Zero —
+    /// the usual case — means the recipe is made of neutral salts and does not move pH by itself.
+    /// </remarks>
+    public double AcidEquivalents => Anions - Cations;
+
+    /// <summary>
+    /// Gets <see cref="AcidEquivalents"/> as a fraction of the larger side, or zero for an empty solution.
+    /// </summary>
+    /// <remarks>
+    /// Relative rather than absolute, so the same figure means the same thing for a seedling feed and a
+    /// full-strength tomato recipe.
+    /// </remarks>
+    public double RelativeDifference
+    {
+        get
+        {
+            double larger = Math.Max(Cations, Anions);
+            return larger > 0 ? AcidEquivalents / larger : 0;
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the charges balance to within 2%.
+    /// </summary>
+    /// <remarks>
+    /// True for a recipe of neutral salts, which balances exactly; the tolerance is for rounding, not for
+    /// chemistry. False means the recipe includes an acid or a basic salt, which is a fact about it rather
+    /// than a fault — read <see cref="AcidEquivalents"/> for the size and direction.
+    /// </remarks>
+    public bool IsChargeNeutral => Math.Abs(RelativeDifference) <= 0.02;
+}

--- a/src/SYT.NPKTools/Nutrients/MolarProfile.cs
+++ b/src/SYT.NPKTools/Nutrients/MolarProfile.cs
@@ -1,0 +1,124 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// A nutrient profile in millimoles per litre (mM).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Ppm is a mass unit and plants take up ions, so ppm makes elements of different atomic weight look
+/// comparable when they are not: 40 ppm of calcium and 40 ppm of magnesium are 1.0 mM and 1.65 mM — the
+/// magnesium is two-thirds again as many ions. Every published formulation in the horticultural
+/// literature — Steiner, Hoagland, the Dutch advisory tables — is stated in mM for that reason, so
+/// working from a paper recipe means converting one way or the other.
+/// </para>
+/// <para>
+/// The conversion is division by atomic weight and nothing else, which is why this covers all sixteen
+/// elements while <see cref="IonBalance"/> deliberately does not.
+/// </para>
+/// </remarks>
+public sealed record MolarProfile
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MolarProfile"/> record.
+    /// </summary>
+    /// <remarks>
+    /// Prefer <see cref="PpmExtensions.AsMillimolar"/> over constructing one directly; the
+    /// constructor exists so that a profile read from a paper recipe can be expressed in its own units.
+    /// </remarks>
+    internal MolarProfile(
+        double nitrate,
+        double ammonium,
+        double amine,
+        double phosphorus,
+        double potassium,
+        double calcium,
+        double magnesium,
+        double sulfur,
+        double iron,
+        double copper,
+        double manganese,
+        double zinc,
+        double boron,
+        double molybdenum,
+        double chlorine,
+        double silicon,
+        double selenium,
+        double sodium)
+    {
+        Nitrate = nitrate;
+        Ammonium = ammonium;
+        Amine = amine;
+        Phosphorus = phosphorus;
+        Potassium = potassium;
+        Calcium = calcium;
+        Magnesium = magnesium;
+        Sulfur = sulfur;
+        Iron = iron;
+        Copper = copper;
+        Manganese = manganese;
+        Zinc = zinc;
+        Boron = boron;
+        Molybdenum = molybdenum;
+        Chlorine = chlorine;
+        Silicon = silicon;
+        Selenium = selenium;
+        Sodium = sodium;
+    }
+
+    /// <summary>Gets nitrate nitrogen in mM.</summary>
+    public double Nitrate { get; }
+
+    /// <summary>Gets ammonium nitrogen in mM.</summary>
+    public double Ammonium { get; }
+
+    /// <summary>Gets amine nitrogen — urea — in mM.</summary>
+    public double Amine { get; }
+
+    /// <summary>Gets total nitrogen in mM, across all three forms.</summary>
+    public double Nitrogen => Nitrate + Ammonium + Amine;
+
+    /// <summary>Gets phosphorus in mM.</summary>
+    public double Phosphorus { get; }
+
+    /// <summary>Gets potassium in mM.</summary>
+    public double Potassium { get; }
+
+    /// <summary>Gets calcium in mM.</summary>
+    public double Calcium { get; }
+
+    /// <summary>Gets magnesium in mM.</summary>
+    public double Magnesium { get; }
+
+    /// <summary>Gets sulfur in mM.</summary>
+    public double Sulfur { get; }
+
+    /// <summary>Gets iron in mM.</summary>
+    public double Iron { get; }
+
+    /// <summary>Gets copper in mM.</summary>
+    public double Copper { get; }
+
+    /// <summary>Gets manganese in mM.</summary>
+    public double Manganese { get; }
+
+    /// <summary>Gets zinc in mM.</summary>
+    public double Zinc { get; }
+
+    /// <summary>Gets boron in mM.</summary>
+    public double Boron { get; }
+
+    /// <summary>Gets molybdenum in mM.</summary>
+    public double Molybdenum { get; }
+
+    /// <summary>Gets chlorine in mM.</summary>
+    public double Chlorine { get; }
+
+    /// <summary>Gets silicon in mM.</summary>
+    public double Silicon { get; }
+
+    /// <summary>Gets selenium in mM.</summary>
+    public double Selenium { get; }
+
+    /// <summary>Gets sodium in mM.</summary>
+    public double Sodium { get; }
+}

--- a/src/SYT.NPKTools/Nutrients/NutrientExcess.cs
+++ b/src/SYT.NPKTools/Nutrients/NutrientExcess.cs
@@ -1,0 +1,24 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// Reports an element the source water already supplies in excess of the target.
+/// </summary>
+/// <param name="Element">
+/// The element symbol, using the same names <see cref="IPpmTargetParser"/> accepts — <c>N</c>,
+/// <c>P</c>, <c>K</c>, <c>Ca</c> and so on — so it can be fed straight back into a target string.
+/// </param>
+/// <param name="InWater">What the water supplies, in ppm.</param>
+/// <param name="Target">What was asked for, in ppm.</param>
+/// <remarks>
+/// This is not an error, it is a fact about the water. Fertilizer can only add, so an element already
+/// above target cannot be brought down by mixing: the options are to raise the target, or to dilute the
+/// source water with something purer. Hard water hitting a low calcium target is the everyday case, and
+/// it is exactly why growers buy reverse osmosis equipment.
+/// </remarks>
+public sealed record NutrientExcess(string Element, double InWater, double Target)
+{
+    /// <summary>
+    /// Gets how much the water overshoots the target by, in ppm.
+    /// </summary>
+    public double Overshoot => InWater - Target;
+}

--- a/src/SYT.NPKTools/Nutrients/NutrientRatios.cs
+++ b/src/SYT.NPKTools/Nutrients/NutrientRatios.cs
@@ -1,0 +1,113 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// The ratios between nutrients in a solution, which is how a nutrient profile is normally judged.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Absolute ppm figures say how strong a solution is; the ratios say what it will actually do. Two
+/// solutions with identical total strength behave completely differently if one has four times the
+/// potassium relative to calcium.
+/// </para>
+/// <para>
+/// Every ratio is expressed as "how many parts of the first element per one part of the second", so
+/// <see cref="PotassiumToCalcium"/> of 2 means twice as much potassium as calcium by weight. A ratio is
+/// null when its denominator is zero, because "unbounded" is not a number and silently returning zero
+/// or infinity would be worse than saying nothing.
+/// </para>
+/// <para>
+/// Obtain one with <see cref="PpmExtensions.Ratios"/>.
+/// </para>
+/// </remarks>
+public sealed record NutrientRatios
+{
+    /// <summary>
+    /// Gets the ratio of nitrate to ammonium nitrogen.
+    /// </summary>
+    /// <remarks>
+    /// The one ratio worth watching most closely, because it drives pH movement at the root rather than
+    /// plant nutrition: taking up ammonium acidifies the root zone, taking up nitrate alkalizes it. A
+    /// solution that is mostly nitrate drifts pH up over the days after mixing, one with a large
+    /// ammonium share drifts down. Null when there is no ammonium, which is the common case for a
+    /// nitrate-only mix.
+    /// </remarks>
+    public double? NitrateToAmmonium { get; }
+
+    /// <summary>
+    /// Gets the ratio of total nitrogen to potassium.
+    /// </summary>
+    /// <remarks>
+    /// Broadly tracks vegetative versus generative balance: relatively more nitrogen favours leaf and
+    /// shoot growth, relatively more potassium favours fruiting and ripening.
+    /// </remarks>
+    public double? NitrogenToPotassium { get; }
+
+    /// <summary>
+    /// Gets the ratio of potassium to calcium.
+    /// </summary>
+    /// <remarks>
+    /// The two compete for uptake, so a high value can starve a plant of calcium even when the absolute
+    /// calcium figure looks adequate.
+    /// </remarks>
+    public double? PotassiumToCalcium { get; }
+
+    /// <summary>
+    /// Gets the ratio of calcium to magnesium.
+    /// </summary>
+    /// <remarks>
+    /// These also compete. Both directions cause visible trouble, which is why the ratio is watched
+    /// rather than the two figures separately.
+    /// </remarks>
+    public double? CalciumToMagnesium { get; }
+
+    /// <summary>
+    /// Gets the ratio of potassium to magnesium.
+    /// </summary>
+    public double? PotassiumToMagnesium { get; }
+
+    /// <summary>
+    /// Gets the ratio of nitrogen to sulfur.
+    /// </summary>
+    public double? NitrogenToSulfur { get; }
+
+    /// <summary>
+    /// Gets the ratio of nitrogen to phosphorus.
+    /// </summary>
+    public double? NitrogenToPhosphorus { get; }
+
+    /// <summary>
+    /// Gets the total of every nutrient concentration, in ppm.
+    /// </summary>
+    /// <remarks>
+    /// Useful as a strength figure, but not the same thing as a TDS meter reading: a meter infers
+    /// dissolved solids from electrical conductivity, which depends on which ions are present and not
+    /// merely on how much of everything there is.
+    /// </remarks>
+    public double TotalPpm { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NutrientRatios"/> record from a measured solution.
+    /// </summary>
+    /// <param name="ppm">The nutrient concentrations to describe.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ppm"/> is null.</exception>
+    public NutrientRatios(Ppm ppm)
+    {
+        ArgumentNullException.ThrowIfNull(ppm);
+
+        TotalPpm = ppm.Value;
+
+        NitrateToAmmonium = Divide(ppm.Nitrogen.Nitrate, ppm.Nitrogen.Ammonium);
+        NitrogenToPotassium = Divide(ppm.Nitrogen.Value, ppm.Potassium.Value);
+        PotassiumToCalcium = Divide(ppm.Potassium.Value, ppm.Calcium.Value);
+        CalciumToMagnesium = Divide(ppm.Calcium.Value, ppm.Magnesium.Value);
+        PotassiumToMagnesium = Divide(ppm.Potassium.Value, ppm.Magnesium.Value);
+        NitrogenToSulfur = Divide(ppm.Nitrogen.Value, ppm.Sulfur.Value);
+        NitrogenToPhosphorus = Divide(ppm.Nitrogen.Value, ppm.Phosphorus.Value);
+    }
+
+    /// <summary>
+    /// Divides, returning null rather than infinity or NaN when the denominator is absent.
+    /// </summary>
+    private static double? Divide(double numerator, double denominator) =>
+        denominator > 0 ? numerator / denominator : null;
+}

--- a/src/SYT.NPKTools/Nutrients/WaterAdjustedTarget.cs
+++ b/src/SYT.NPKTools/Nutrients/WaterAdjustedTarget.cs
@@ -1,0 +1,26 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// A nutrient target with the source water's own contribution already deducted, plus a note of
+/// anything the water oversupplies.
+/// </summary>
+/// <param name="Target">
+/// What the fertilizers still have to provide. Feed this to the optimizer, not the original target.
+/// </param>
+/// <param name="Excesses">
+/// Elements the water already supplies above the target, if any. Their entries in
+/// <paramref name="Target"/> are zero, because no amount of fertilizer can reduce them.
+/// </param>
+/// <remarks>
+/// Deducting the water is deliberately a separate step ahead of the optimizer rather than something
+/// buried inside it: the result is an ordinary <see cref="PpmTarget"/>, so nothing downstream needs to
+/// know that water was ever involved, and the arithmetic stays inspectable.
+/// </remarks>
+public sealed record WaterAdjustedTarget(PpmTarget Target, IReadOnlyList<NutrientExcess> Excesses)
+{
+    /// <summary>
+    /// Gets a value indicating whether the water oversupplies at least one element, meaning the
+    /// original target cannot be reached exactly by adding fertilizer.
+    /// </summary>
+    public bool HasExcesses => Excesses.Count > 0;
+}

--- a/src/SYT.NPKTools/Nutrients/WaterProfile.cs
+++ b/src/SYT.NPKTools/Nutrients/WaterProfile.cs
@@ -1,0 +1,199 @@
+namespace SYT.NPKTools.Nutrients;
+
+/// <summary>
+/// The nutrients already present in the source water, in parts per million.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tap and well water is rarely blank: calcium, magnesium, sulfur and sodium are routinely present in
+/// quantities that matter, and ignoring them makes every calculated mix wrong by that amount. Subtract
+/// a profile from a target with <see cref="PpmTargetExtensions.AdjustFor"/> before optimizing.
+/// </para>
+/// <para>
+/// Unlike <see cref="Ppm"/> this carries no water volume, because a water analysis is a concentration
+/// and holds regardless of how much of it you use. It reuses the same value objects, so the numbers on
+/// a laboratory report go in unchanged.
+/// </para>
+/// <para>
+/// Build one with <see cref="WaterProfileBuilder"/>. An all-zero profile — reverse osmosis or
+/// distilled — leaves a target untouched.
+/// </para>
+/// </remarks>
+public sealed class WaterProfile
+{
+    /// <summary>
+    /// Gets the nitrogen already in the water. Water analyses normally report nitrate; ammonium and
+    /// amine are unusual in a municipal supply but are representable.
+    /// </summary>
+    public NitrogenPpm Nitrogen { get; }
+
+    /// <summary>
+    /// Gets the phosphorus already in the water.
+    /// </summary>
+    public PhosphorusPpm Phosphorus { get; }
+
+    /// <summary>
+    /// Gets the potassium already in the water.
+    /// </summary>
+    public PotassiumPpm Potassium { get; }
+
+    /// <summary>
+    /// Gets the calcium already in the water. Together with magnesium this is what "hard water" means,
+    /// and it is the most common reason a target cannot be met without dilution.
+    /// </summary>
+    public CalciumPpm Calcium { get; }
+
+    /// <summary>
+    /// Gets the magnesium already in the water.
+    /// </summary>
+    public MagnesiumPpm Magnesium { get; }
+
+    /// <summary>
+    /// Gets the sulfur already in the water, as elemental S rather than sulfate.
+    /// </summary>
+    public SulfurPpm Sulfur { get; }
+
+    /// <summary>
+    /// Gets the iron already in the water.
+    /// </summary>
+    public IronPpm Iron { get; }
+
+    /// <summary>
+    /// Gets the copper already in the water.
+    /// </summary>
+    public CopperPpm Copper { get; }
+
+    /// <summary>
+    /// Gets the manganese already in the water.
+    /// </summary>
+    public ManganesePpm Manganese { get; }
+
+    /// <summary>
+    /// Gets the zinc already in the water.
+    /// </summary>
+    public ZincPpm Zinc { get; }
+
+    /// <summary>
+    /// Gets the boron already in the water.
+    /// </summary>
+    public BoronPpm Boron { get; }
+
+    /// <summary>
+    /// Gets the molybdenum already in the water.
+    /// </summary>
+    public MolybdenumPpm Molybdenum { get; }
+
+    /// <summary>
+    /// Gets the chlorine already in the water. Along with sodium this is what accumulates and is the
+    /// usual reason growers move to reverse osmosis.
+    /// </summary>
+    public ChlorinePpm Chlorine { get; }
+
+    /// <summary>
+    /// Gets the silicon already in the water.
+    /// </summary>
+    public SiliconPpm Silicon { get; }
+
+    /// <summary>
+    /// Gets the selenium already in the water.
+    /// </summary>
+    public SeleniumPpm Selenium { get; }
+
+    /// <summary>
+    /// Gets the sodium already in the water.
+    /// </summary>
+    public SodiumPpm Sodium { get; }
+
+    /// <summary>
+    /// A profile with every value zero: reverse osmosis, distilled, or rain water. Subtracting it
+    /// leaves a target unchanged.
+    /// </summary>
+    public static readonly WaterProfile Pure = new WaterProfileBuilder().Build();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WaterProfile"/> class.
+    /// </summary>
+    /// <param name="nitrogen">Nitrogen already in the water.</param>
+    /// <param name="phosphorus">Phosphorus already in the water.</param>
+    /// <param name="potassium">Potassium already in the water.</param>
+    /// <param name="calcium">Calcium already in the water.</param>
+    /// <param name="magnesium">Magnesium already in the water.</param>
+    /// <param name="sulfur">Sulfur already in the water.</param>
+    /// <param name="iron">Iron already in the water.</param>
+    /// <param name="copper">Copper already in the water.</param>
+    /// <param name="manganese">Manganese already in the water.</param>
+    /// <param name="zinc">Zinc already in the water.</param>
+    /// <param name="boron">Boron already in the water.</param>
+    /// <param name="molybdenum">Molybdenum already in the water.</param>
+    /// <param name="chlorine">Chlorine already in the water.</param>
+    /// <param name="silicon">Silicon already in the water.</param>
+    /// <param name="selenium">Selenium already in the water.</param>
+    /// <param name="sodium">Sodium already in the water.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+    public WaterProfile(
+        NitrogenPpm nitrogen,
+        PhosphorusPpm phosphorus,
+        PotassiumPpm potassium,
+        CalciumPpm calcium,
+        MagnesiumPpm magnesium,
+        SulfurPpm sulfur,
+        IronPpm iron,
+        CopperPpm copper,
+        ManganesePpm manganese,
+        ZincPpm zinc,
+        BoronPpm boron,
+        MolybdenumPpm molybdenum,
+        ChlorinePpm chlorine,
+        SiliconPpm silicon,
+        SeleniumPpm selenium,
+        SodiumPpm sodium)
+    {
+        ArgumentNullException.ThrowIfNull(nitrogen);
+        Nitrogen = nitrogen;
+
+        ArgumentNullException.ThrowIfNull(phosphorus);
+        Phosphorus = phosphorus;
+
+        ArgumentNullException.ThrowIfNull(potassium);
+        Potassium = potassium;
+
+        ArgumentNullException.ThrowIfNull(calcium);
+        Calcium = calcium;
+
+        ArgumentNullException.ThrowIfNull(magnesium);
+        Magnesium = magnesium;
+
+        ArgumentNullException.ThrowIfNull(sulfur);
+        Sulfur = sulfur;
+
+        ArgumentNullException.ThrowIfNull(iron);
+        Iron = iron;
+
+        ArgumentNullException.ThrowIfNull(copper);
+        Copper = copper;
+
+        ArgumentNullException.ThrowIfNull(manganese);
+        Manganese = manganese;
+
+        ArgumentNullException.ThrowIfNull(zinc);
+        Zinc = zinc;
+
+        ArgumentNullException.ThrowIfNull(boron);
+        Boron = boron;
+
+        ArgumentNullException.ThrowIfNull(molybdenum);
+        Molybdenum = molybdenum;
+
+        ArgumentNullException.ThrowIfNull(chlorine);
+        Chlorine = chlorine;
+
+        ArgumentNullException.ThrowIfNull(silicon);
+        Silicon = silicon;
+
+        ArgumentNullException.ThrowIfNull(selenium);
+        Selenium = selenium;
+
+        ArgumentNullException.ThrowIfNull(sodium);
+        Sodium = sodium;
+    }
+}

--- a/src/SYT.NPKTools/Presets/BundleGenerationSettings.cs
+++ b/src/SYT.NPKTools/Presets/BundleGenerationSettings.cs
@@ -1,0 +1,26 @@
+namespace SYT.NPKTools;
+
+/// <summary>
+/// Bounds on how many bundles are generated from a list of salts.
+/// </summary>
+/// <remarks>
+/// Generation produces one bundle per salt plus one holding everything, so the count tracks the size of
+/// the shelf and only needs bounding for an unusually long list. Whatever the limit discards is reported
+/// in <see cref="GeneratedBundles.BundlesDropped"/> rather than dropped quietly.
+/// </remarks>
+public sealed record BundleGenerationSettings
+{
+    /// <summary>
+    /// Gets the settings used when a caller does not supply any.
+    /// </summary>
+    public static BundleGenerationSettings Default { get; } = new();
+
+    /// <summary>
+    /// Gets how many bundles may be returned. Defaults to 64.
+    /// </summary>
+    /// <remarks>
+    /// A guard against a runaway list rather than a curation limit: every bundle costs a solve, and the
+    /// default only binds on a shelf of more than 63 salts. The built-in catalogue draws on 17.
+    /// </remarks>
+    public int MaxBundles { get; init; } = 64;
+}

--- a/src/SYT.NPKTools/Presets/CustomFertilizerBundleRepository.cs
+++ b/src/SYT.NPKTools/Presets/CustomFertilizerBundleRepository.cs
@@ -1,0 +1,77 @@
+using SYT.NPKTools.Fertilizers;
+
+namespace SYT.NPKTools;
+
+/// <summary>
+/// A bundle repository built from a person's own salts instead of the preset catalogue.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the whole answer to "I want to use what I have". It is an
+/// <see cref="IFertilizerBundleRepository"/>, so everything downstream — the optimization service, the
+/// solver, the ppm calculator, the concentrate split — works on custom salts exactly as it does on the
+/// presets. Nothing else in the library needs to know the difference.
+/// </para>
+/// <para>
+/// Bundles are generated once and cached, the same as the preset repository, because generation walks a
+/// cross product and a caller may hit <see cref="Macro"/> repeatedly.
+/// </para>
+/// </remarks>
+public sealed class CustomFertilizerBundleRepository : IFertilizerBundleRepository
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomFertilizerBundleRepository"/> class.
+    /// </summary>
+    /// <param name="salts">
+    /// The salts on hand, in any order and any mix of macro and micro. Weights are irrelevant here —
+    /// the optimizer computes them — so a salt need only carry its composition.
+    /// </param>
+    /// <param name="settings">
+    /// Bounds on how many bundles to generate. Defaults to <see cref="BundleGenerationSettings.Default"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="salts"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when either limit in <paramref name="settings"/> is not positive.</exception>
+    public CustomFertilizerBundleRepository(
+        IEnumerable<Fertilizer> salts,
+        BundleGenerationSettings? settings = null)
+    {
+        ArgumentNullException.ThrowIfNull(salts);
+
+        Fertilizer[] all = [.. salts];
+
+        MacroGeneration = FertilizerBundleGenerator.GenerateMacro(all, settings);
+        MicroGeneration = FertilizerBundleGenerator.GenerateMicro(all, settings);
+        UnusableSalts =
+        [
+            .. all.Where(f => !FertilizerBundleGenerator.IsUsable(f))
+                  .Select(f => f.Name.Value)
+                  .Distinct(StringComparer.OrdinalIgnoreCase)
+                  .OrderBy(name => name, StringComparer.Ordinal)
+        ];
+    }
+
+    /// <summary>
+    /// Gets the macro bundles together with what generation left out.
+    /// </summary>
+    public GeneratedBundles MacroGeneration { get; }
+
+    /// <summary>
+    /// Gets the micro bundles together with what generation left out.
+    /// </summary>
+    public GeneratedBundles MicroGeneration { get; }
+
+    /// <summary>
+    /// Gets the names of supplied salts that carry no element any target can ask for.
+    /// </summary>
+    /// <remarks>
+    /// Reported rather than ignored: a salt listed here is in no bundle, and a caller who thinks it is
+    /// being used would misread every recipe that comes back.
+    /// </remarks>
+    public IReadOnlyList<string> UnusableSalts { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<IReadOnlyList<Fertilizer>> Macro() => MacroGeneration.Bundles;
+
+    /// <inheritdoc />
+    public IReadOnlyList<IReadOnlyList<Fertilizer>> Micro() => MicroGeneration.Bundles;
+}

--- a/src/SYT.NPKTools/Presets/FertilizerBundleGenerator.cs
+++ b/src/SYT.NPKTools/Presets/FertilizerBundleGenerator.cs
@@ -1,0 +1,184 @@
+using SYT.NPKTools.Fertilizers;
+using SYT.NPKTools.Internal;
+
+namespace SYT.NPKTools;
+
+/// <summary>
+/// Builds optimization bundles from whatever salts a person actually has.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The built-in catalogue offers eighteen macro bundles because they were written out by hand. Someone
+/// working from their own shelf had no equivalent: one list of salts is one bundle, so they saw a single
+/// recipe where the presets give a dozen to compare. This closes that gap — the same salts, the same
+/// solver, the same number of alternatives.
+/// </para>
+/// <para>
+/// <b>How.</b> The first bundle holds everything on the shelf; each of the others leaves out exactly one
+/// salt. Handing the optimizer every salt at once yields the single best mix it can find, and every
+/// superset of that yields the same mix again — so alternatives can only come from taking something
+/// away. Removing one salt forces the linear program to route around it, which is both a genuinely
+/// different recipe and the question a grower actually asks: <em>what does this look like without the
+/// MKP?</em>
+/// </para>
+/// <para>
+/// <b>Why not combinations.</b> Two other strategies were measured against the hand-written catalogue on
+/// three macro targets, counting distinct recipes returned. Picking one source per element and taking the
+/// cross product scored 5; holding out pairs and triples as well as singles scored the same 21 as
+/// holding out singles alone, because a smaller subset either reproduces a recipe already found or
+/// solves nothing. The hand-written catalogue scored 19. Depth beyond one buys nothing, and building
+/// bundles up from per-element choices produces bundles too small to satisfy six simultaneous
+/// constraints at non-negative weights.
+/// </para>
+/// </remarks>
+public static class FertilizerBundleGenerator
+{
+    /// <summary>
+    /// The elements a macro target can ask for.
+    /// </summary>
+    private static readonly string[] MacroElements =
+        [Names.N, Names.P, Names.K, Names.Ca, Names.Mg, Names.S];
+
+    /// <summary>
+    /// The elements a micro target can ask for. Chlorine and sodium are absent deliberately: they arrive
+    /// as counter-ions rather than being dosed for, so reporting them as uncovered would be noise.
+    /// </summary>
+    private static readonly string[] MicroElements =
+        [Names.Fe, Names.Cu, Names.Mn, Names.Zn, Names.B, Names.Mo, Names.Si, Names.Se];
+
+    /// <summary>
+    /// Generates macro bundles from the salts that carry macro nutrients.
+    /// </summary>
+    /// <param name="available">The salts on hand. Micro salts are ignored; see <see cref="IsMicro"/>.</param>
+    /// <param name="settings">Bounds on the output. Defaults to <see cref="BundleGenerationSettings.Default"/>.</param>
+    /// <returns>The bundles, and what generation left out.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="available"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="BundleGenerationSettings.MaxBundles"/> is not positive.</exception>
+    public static GeneratedBundles GenerateMacro(
+        IEnumerable<Fertilizer> available,
+        BundleGenerationSettings? settings = null)
+    {
+        ArgumentNullException.ThrowIfNull(available);
+
+        // Usable as well as non-micro: a salt of nothing but sodium and chloride is neither tier's, and
+        // admitting it here would put a salt in every macro bundle that no target can ever call for.
+        return Generate(available.Where(f => IsUsable(f) && !IsMicro(f)), MacroElements, settings);
+    }
+
+    /// <summary>
+    /// Generates micro bundles from the salts that carry micronutrients.
+    /// </summary>
+    /// <param name="available">The salts on hand. Macro-only salts are ignored.</param>
+    /// <param name="settings">Bounds on the output. Defaults to <see cref="BundleGenerationSettings.Default"/>.</param>
+    /// <returns>The bundles, and what generation left out.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="available"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <see cref="BundleGenerationSettings.MaxBundles"/> is not positive.</exception>
+    public static GeneratedBundles GenerateMicro(
+        IEnumerable<Fertilizer> available,
+        BundleGenerationSettings? settings = null)
+    {
+        ArgumentNullException.ThrowIfNull(available);
+
+        return Generate(available.Where(IsMicro), MicroElements, settings);
+    }
+
+    /// <summary>
+    /// Reports whether a salt belongs to the micro tier.
+    /// </summary>
+    /// <remarks>
+    /// Carrying any micronutrient is what decides it, even when the salt also carries a macro element.
+    /// Iron sulfate is a micro salt whose sulfur is incidental: dosing it to meet a sulfur target would
+    /// mean iron at a hundred times the intended rate. This mirrors how the built-in catalogue is split.
+    /// </remarks>
+    /// <param name="fertilizer">The salt to classify.</param>
+    /// <returns><see langword="true"/> when the salt carries at least one micronutrient.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fertilizer"/> is null.</exception>
+    public static bool IsMicro(Fertilizer fertilizer)
+    {
+        ArgumentNullException.ThrowIfNull(fertilizer);
+
+        return MicroElements.Any(element => Content(fertilizer, element) > 0);
+    }
+
+    /// <summary>
+    /// Reports whether a salt carries any element a target can ask for.
+    /// </summary>
+    /// <remarks>
+    /// A salt of nothing but sodium and chloride is real — table salt — but there is no target it helps
+    /// meet, so it belongs in no bundle. Callers surface these rather than let them look included.
+    /// </remarks>
+    /// <param name="fertilizer">The salt to check.</param>
+    /// <returns><see langword="true"/> when the salt carries at least one macro or micro nutrient.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fertilizer"/> is null.</exception>
+    public static bool IsUsable(Fertilizer fertilizer)
+    {
+        ArgumentNullException.ThrowIfNull(fertilizer);
+
+        return MacroElements.Concat(MicroElements).Any(element => Content(fertilizer, element) > 0);
+    }
+
+    private static GeneratedBundles Generate(
+        IEnumerable<Fertilizer> available,
+        string[] elements,
+        BundleGenerationSettings? settings)
+    {
+        settings ??= BundleGenerationSettings.Default;
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            settings.MaxBundles,
+            nameof(BundleGenerationSettings.MaxBundles));
+
+        // The same salt listed twice is one salt. Left in, it would become two identical columns in the
+        // linear program — harmless to the answer, but the recipe would list the salt twice. Sorting by
+        // name makes the output stable regardless of the order the caller supplied.
+        List<Fertilizer> salts = [.. available
+            .DistinctBy(f => f.Name.Value, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(f => f.Name.Value, StringComparer.Ordinal)];
+
+        if (salts.Count == 0)
+        {
+            return GeneratedBundles.Empty;
+        }
+
+        List<string> uncovered =
+            [.. elements.Where(element => !salts.Any(f => Content(f, element) > 0))];
+
+        // Everything on the shelf, then the shelf minus each salt in turn. A bundle of one salt cannot
+        // be reduced further, so a single-salt shelf yields exactly that one bundle.
+        List<IReadOnlyList<Fertilizer>> bundles = [salts];
+
+        if (salts.Count > 1)
+        {
+            for (int held = 0; held < salts.Count && bundles.Count < settings.MaxBundles; held++)
+            {
+                bundles.Add([.. salts.Where((_, index) => index != held)]);
+            }
+        }
+
+        int candidates = salts.Count > 1 ? salts.Count + 1 : 1;
+        int dropped = Math.Max(0, candidates - settings.MaxBundles);
+
+        return new GeneratedBundles(bundles, uncovered, dropped);
+    }
+
+    /// <summary>
+    /// Gets how much of an element a salt contains, as a percentage by weight.
+    /// </summary>
+    private static double Content(Fertilizer fertilizer, string element) => element switch
+    {
+        Names.N => fertilizer.Nitrogen.Value,
+        Names.P => fertilizer.Phosphorus.Value,
+        Names.K => fertilizer.Potassium.Value,
+        Names.Ca => fertilizer.Calcium.Value,
+        Names.Mg => fertilizer.Magnesium.Value,
+        Names.S => fertilizer.Sulfur.Value,
+        Names.Fe => fertilizer.Iron.Value,
+        Names.Cu => fertilizer.Copper.Value,
+        Names.Mn => fertilizer.Manganese.Value,
+        Names.Zn => fertilizer.Zinc.Value,
+        Names.B => fertilizer.Boron.Value,
+        Names.Mo => fertilizer.Molybdenum.Value,
+        Names.Si => fertilizer.Silicon.Value,
+        Names.Se => fertilizer.Selenium.Value,
+        _ => 0
+    };
+}

--- a/src/SYT.NPKTools/Presets/GeneratedBundles.cs
+++ b/src/SYT.NPKTools/Presets/GeneratedBundles.cs
@@ -1,0 +1,40 @@
+using SYT.NPKTools.Fertilizers;
+
+namespace SYT.NPKTools;
+
+/// <summary>
+/// Bundles generated from a list of salts, together with anything generation had to leave out.
+/// </summary>
+/// <param name="Bundles">
+/// The bundles. The first holds every salt supplied; each of the rest leaves out exactly one, in name
+/// order. A caller wanting to label a bundle can take the set difference against the first —
+/// <c>Bundles[0].Except(bundle)</c> — which is what makes a recipe presentable as "without the MKP".
+/// </param>
+/// <param name="UncoveredElements">
+/// Elements no supplied salt contains, as chemical symbols. A target asking for one of these cannot be
+/// met by any bundle, and saying which salt is missing is more use than returning no solutions and
+/// leaving the caller to guess why.
+/// </param>
+/// <param name="BundlesDropped">
+/// How many bundles exceeded <see cref="BundleGenerationSettings.MaxBundles"/> and were discarded.
+/// </param>
+/// <remarks>
+/// The two reporting fields are the point of this type. A generator that quietly ignored a missing
+/// magnesium source, or returned eight bundles from a shelf that warranted eighty, would read as "this
+/// is everything" when it was not.
+/// </remarks>
+public sealed record GeneratedBundles(
+    IReadOnlyList<IReadOnlyList<Fertilizer>> Bundles,
+    IReadOnlyList<string> UncoveredElements,
+    int BundlesDropped)
+{
+    /// <summary>
+    /// Gets an empty result, for a shelf holding nothing this tier can use.
+    /// </summary>
+    public static GeneratedBundles Empty { get; } = new([], [], 0);
+
+    /// <summary>
+    /// Gets a value indicating whether every element is reachable and no bundle was discarded.
+    /// </summary>
+    public bool IsComplete => UncoveredElements.Count == 0 && BundlesDropped == 0;
+}

--- a/tests/SYT.NPKTools.IntegrationTests/CustomSaltsTests.cs
+++ b/tests/SYT.NPKTools.IntegrationTests/CustomSaltsTests.cs
@@ -1,0 +1,173 @@
+using SYT.NPKTools.Concentrates;
+using SYT.NPKTools.Fertilizers;
+using SYT.NPKTools.Nutrients;
+using Xunit;
+
+namespace SYT.NPKTools.IntegrationTests;
+
+/// <summary>
+/// Covers the whole path a person with their own salts takes: a shelf, their tap water, a target, and a
+/// concentrate to dose from.
+/// </summary>
+/// <remarks>
+/// The unit tests pin the shape of generated bundles. What they cannot show is that the shape is any
+/// use, so these run the real solver end to end and assert the recipes land on target. Generation that
+/// produced a tidy list of bundles none of which solved would pass every unit test and be worthless.
+/// </remarks>
+public class CustomSaltsTests
+{
+    /// <summary>
+    /// A shelf of the six salts a hobbyist actually buys, defined here rather than taken from the preset
+    /// catalogue so the test exercises the custom path for real.
+    /// </summary>
+    private static Fertilizer[] Shelf() =>
+    [
+        new FertilizerBuilder().AddName("Calcium Nitrate Tetrahydrate").AddType(ConcentrateType.A)
+            .AddNo3(11.86).AddCaNonChelated(16.97).Build(),
+        new FertilizerBuilder().AddName("Potassium Nitrate").AddType(ConcentrateType.A)
+            .AddNo3(13.85).AddK(38.67).Build(),
+        new FertilizerBuilder().AddName("Magnesium Sulfate Heptahydrate").AddType(ConcentrateType.B)
+            .AddMgNonChelated(9.86).AddS(13.01).Build(),
+        new FertilizerBuilder().AddName("Monopotassium Phosphate").AddType(ConcentrateType.B)
+            .AddP(22.76).AddK(28.73).Build(),
+        new FertilizerBuilder().AddName("Potassium Sulfate").AddType(ConcentrateType.B)
+            .AddK(44.87).AddS(18.4).Build(),
+        new FertilizerBuilder().AddName("Magnesium Nitrate Hexahydrate").AddType(ConcentrateType.A)
+            .AddNo3(10.93).AddMgNonChelated(9.48).Build(),
+    ];
+
+    private static PpmTarget Target() => new PpmTargetBuilder()
+        .AddN(150).AddP(50).AddK(210).AddCa(160).AddMg(50).AddS(65).AddLiters(100)
+        .Build();
+
+    /// <summary>
+    /// The claim the feature rests on: a caller's own salts yield several recipes, not one. Before
+    /// generation, a custom shelf was a single bundle and therefore a single answer, while the preset
+    /// catalogue offered a dozen to compare.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void OwnSalts_YieldSeveralDistinctRecipes()
+    {
+        // Arrange
+        IFertilizerOptimizationService service = NpkTools.CreateOptimizationService(Shelf());
+
+        // Act
+        Solutions found = service.FindMacroSolutions(Target());
+
+        // Assert
+        Assert.True(found.Count > 1, $"expected several recipes from six salts, got {found.Count}");
+    }
+
+    /// <summary>
+    /// Every recipe must actually hit the target. A generated bundle that returns a mix missing its
+    /// calcium is worse than a bundle that returns nothing.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void OwnSalts_EveryRecipeMeetsTheTarget()
+    {
+        // Arrange
+        IFertilizerOptimizationService service = NpkTools.CreateOptimizationService(Shelf());
+        IPpmCalculationService calculator = NpkTools.CreatePpmCalculator();
+        PpmTarget target = Target();
+
+        // Act
+        Solutions found = service.FindMacroSolutions(target);
+
+        // Assert
+        Assert.NotEmpty(found);
+        foreach (Solution recipe in found)
+        {
+            Ppm actual = calculator.CalculatePpm([.. recipe], recipe.WaterLiters);
+
+            Assert.Equal(target.N.Value, actual.Nitrogen.Value, 1);
+            Assert.Equal(target.P.Value, actual.Phosphorus.Value, 1);
+            Assert.Equal(target.K.Value, actual.Potassium.Value, 1);
+            Assert.Equal(target.Ca.Value, actual.Calcium.Value, 1);
+            Assert.Equal(target.Mg.Value, actual.Magnesium.Value, 1);
+        }
+    }
+
+    /// <summary>
+    /// Each generated bundle is meant to force a different route to the same target, so the recipes must
+    /// differ from one another. Identical recipes would mean the bundles were doing no work.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void OwnSalts_RecipesDifferFromEachOther()
+    {
+        // Arrange
+        IFertilizerOptimizationService service = NpkTools.CreateOptimizationService(Shelf());
+
+        // Act
+        Solutions found = service.FindMacroSolutions(Target());
+
+        // Assert
+        IEnumerable<string> signatures = found.Select(recipe => string.Join(
+            '|',
+            recipe.OrderBy(f => f.Name.Value)
+                  .Select(f => $"{f.Name.Value}:{f.Weight.Value:F2}")));
+
+        Assert.Equal(found.Count, signatures.Distinct().Count());
+    }
+
+    /// <summary>
+    /// The three features have to compose, because in practice they are used together: the water is
+    /// deducted, the caller's own salts meet what is left, and the result is stored as a concentrate.
+    /// Each step is tested alone elsewhere; this asserts the chain holds — the finished tank, water
+    /// included, lands on the original target.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void OwnSalts_WithSourceWaterAndConcentrate_LandOnTheOriginalTarget()
+    {
+        // Arrange
+        WaterProfile water = new WaterProfileBuilder().AddCa(45).AddMg(12).AddS(18).Build();
+        PpmTarget target = Target();
+        IFertilizerOptimizationService service = NpkTools.CreateOptimizationService(Shelf());
+        IPpmCalculationService calculator = NpkTools.CreatePpmCalculator();
+
+        // Act
+        PpmTarget adjusted = target.AdjustFor(water).Target;
+        Solution recipe = service.FindMacroSolutions(adjusted)[0];
+        ConcentratePlan plan = recipe.AsConcentrate(concentrateLiters: 1);
+        Ppm fromSalts = calculator.CalculatePpm([.. recipe], recipe.WaterLiters);
+
+        // Assert — the salts cover the shortfall, and the water supplies the rest
+        Assert.Equal(target.Ca.Value, fromSalts.Calcium.Value + water.Calcium.Value, 1);
+        Assert.Equal(target.Mg.Value, fromSalts.Magnesium.Value + water.Magnesium.Value, 1);
+
+        // Assert — concentrating moves the water, not the salt, so the dose reconstitutes that recipe
+        Assert.Equal(100, plan.DilutionRatio, 9);
+        Assert.Equal(10, plan.MillilitresPerLiter, 9);
+        Assert.Equal(
+            recipe.Sum(f => f.Weight.Value),
+            plan.TankA.TotalGrams + plan.TankB.TotalGrams,
+            6);
+        Assert.False(plan.HasPrecipitationRisk);
+    }
+
+    /// <summary>
+    /// A shelf missing an element the target asks for must say which element, not merely return nothing.
+    /// "No solutions" sends someone hunting through their salts; "you have no magnesium source" does not.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void ShelfMissingAnElement_NamesItRatherThanJustFailing()
+    {
+        // Arrange — the same shelf with both magnesium salts removed
+        Fertilizer[] withoutMagnesium =
+            [.. Shelf().Where(f => f.Magnesium.Value == 0)];
+
+        // Act
+        CustomFertilizerBundleRepository repository = NpkTools.CreateBundleRepository(withoutMagnesium);
+        Solutions found = new FertilizerOptimizationService(NpkTools.CreateOptimizer(), repository)
+            .FindMacroSolutions(Target());
+
+        // Assert
+        Assert.Contains("Mg", repository.MacroGeneration.UncoveredElements);
+        Assert.False(repository.MacroGeneration.IsComplete);
+        Assert.Empty(found);
+    }
+}

--- a/tests/SYT.NPKTools.Tests/ConcentrateTests.cs
+++ b/tests/SYT.NPKTools.Tests/ConcentrateTests.cs
@@ -1,0 +1,367 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Concentrates;
+using SYT.NPKTools.Fertilizers;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Covers splitting a working-strength mix into A/B concentrate tanks.
+/// </summary>
+/// <remarks>
+/// Two things can go wrong here and only one of them is arithmetic. The dilution figures are pinned
+/// because a wrong ratio quietly under- or over-feeds every subsequent watering. The precipitation
+/// heuristic is pinned in both directions because a check that fires on monocalcium phosphate — a
+/// legitimately soluble salt carrying calcium and phosphate in one compound — would train users to
+/// ignore it, which is worse than not having it.
+/// </remarks>
+public class ConcentrateTests
+{
+    private const double Precision = 1e-9;
+
+    private static Fertilizer CalciumNitrate(double grams) => new FertilizerBuilder()
+        .AddName("Calcium Nitrate Tetrahydrate")
+        .AddType(ConcentrateType.A)
+        .AddNo3(11.86).AddCaNonChelated(16.97)
+        .AddWeight(grams)
+        .Build();
+
+    private static Fertilizer MagnesiumSulfate(double grams) => new FertilizerBuilder()
+        .AddName("Magnesium Sulfate Heptahydrate")
+        .AddType(ConcentrateType.B)
+        .AddMgNonChelated(9.86).AddS(13.01)
+        .AddWeight(grams)
+        .Build();
+
+    private static Fertilizer MonopotassiumPhosphate(double grams) => new FertilizerBuilder()
+        .AddName("Monopotassium Phosphate")
+        .AddType(ConcentrateType.B)
+        .AddP(22.76).AddK(28.73)
+        .AddWeight(grams)
+        .Build();
+
+    private static Fertilizer PotassiumNitrate(double grams) => new FertilizerBuilder()
+        .AddName("Potassium Nitrate")
+        .AddType(ConcentrateType.A)
+        .AddNo3(13.85).AddK(38.67)
+        .AddWeight(grams)
+        .Build();
+
+    // ---------------------------------------------------------------- the split
+
+    /// <summary>
+    /// The catalogue already knows which tank each salt belongs in. Honouring that is the whole point:
+    /// the split must come from the data, not from re-deriving chemistry the catalogue has already
+    /// settled.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_UsesEachFertilizersOwnTankAssignment()
+    {
+        // Arrange
+        Solution solution = new(
+            [CalciumNitrate(100), PotassiumNitrate(50), MagnesiumSulfate(40), MonopotassiumPhosphate(20)],
+            waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.TankA.Components.Select(c => c.Fertilizer.Name.Value)
+            .Should().BeEquivalentTo(["Calcium Nitrate Tetrahydrate", "Potassium Nitrate"]);
+        plan.TankB.Components.Select(c => c.Fertilizer.Name.Value)
+            .Should().BeEquivalentTo(["Magnesium Sulfate Heptahydrate", "Monopotassium Phosphate"]);
+        plan.HasWarnings.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Concentrating changes how much water the salt goes into, never how much salt is needed. If the
+    /// weights moved, the finished solution would no longer match the recipe the optimizer solved for.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_KeepsTheWorkingRecipesWeights()
+    {
+        // Arrange
+        Solution solution = new([CalciumNitrate(100), MagnesiumSulfate(40)], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 2);
+
+        // Assert
+        plan.TankA.TotalGrams.Should().BeApproximately(100, Precision);
+        plan.TankB.TotalGrams.Should().BeApproximately(40, Precision);
+    }
+
+    /// <summary>
+    /// A mix with no calcium needs no separation, so one tank stays empty. That is the expected outcome
+    /// rather than a degenerate case, and callers need to be able to tell without inspecting counts.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_MixWithoutCalcium_LeavesTankAWithTheNitratesAndBWithTheRest()
+    {
+        // Arrange
+        Solution solution = new([PotassiumNitrate(50), MonopotassiumPhosphate(20)], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.TankA.IsEmpty.Should().BeFalse();
+        plan.TankB.IsEmpty.Should().BeFalse();
+        plan.HasPrecipitationRisk.Should().BeFalse();
+    }
+
+    // ---------------------------------------------------------------- dilution arithmetic
+
+    /// <summary>
+    /// A 100-liter recipe in a 1-liter tank is 1:100, which is 10 ml per liter. These are the two numbers
+    /// a person actually acts on, so both are pinned.
+    /// </summary>
+    [Theory]
+    [InlineData(100, 1, 100, 10)]
+    [InlineData(1000, 5, 200, 5)]
+    [InlineData(50, 2, 25, 40)]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_ComputesDilutionRatioAndDoseFromTheTwoVolumes(
+        double workingLiters,
+        double concentrateLiters,
+        double expectedRatio,
+        double expectedMillilitresPerLiter)
+    {
+        // Arrange
+        Solution solution = new([CalciumNitrate(100)], workingLiters);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters);
+
+        // Assert
+        plan.DilutionRatio.Should().BeApproximately(expectedRatio, Precision);
+        plan.MillilitresPerLiter.Should().BeApproximately(expectedMillilitresPerLiter, Precision);
+    }
+
+    /// <summary>
+    /// Grams per liter is the figure to check against a salt's solubility, and it is the only number in
+    /// the plan that the concentration factor actually moves.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_ReportsEachSaltsStrengthInTheTank()
+    {
+        // Arrange
+        Solution solution = new([CalciumNitrate(100), MagnesiumSulfate(40)], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 2);
+
+        // Assert
+        plan.TankA.Components[0].GramsPerLiter.Should().BeApproximately(50, Precision);
+        plan.TankB.Components[0].GramsPerLiter.Should().BeApproximately(20, Precision);
+        plan.TankA.TotalGramsPerLiter.Should().BeApproximately(50, Precision);
+    }
+
+    // ---------------------------------------------------------------- precipitation heuristic
+
+    /// <summary>
+    /// The warning that earns the feature its keep: calcium and sulfate arriving in one tank from two
+    /// different salts. This is the mistake that produces a cloudy tank and a wasted month of storage,
+    /// and it is exactly what a hand-edited or mislabelled catalogue entry causes.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_CalciumAndSulfateFromDifferentSaltsInOneTank_IsFlagged()
+    {
+        // Arrange — a sulfate mislabelled into tank A, which is how this happens in practice
+        Fertilizer mislabelled = new FertilizerBuilder()
+            .AddName("Magnesium Sulfate Heptahydrate")
+            .AddType(ConcentrateType.A)
+            .AddMgNonChelated(9.86).AddS(13.01)
+            .AddWeight(40)
+            .Build();
+        Solution solution = new([CalciumNitrate(100), mislabelled], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.HasPrecipitationRisk.Should().BeTrue();
+        ConcentrateWarning warning = plan.Warnings.Single();
+        warning.Kind.Should().Be(ConcentrateWarningKind.PrecipitationRisk);
+        warning.Tank.Should().Be(ConcentrateType.A);
+        warning.Fertilizers.Should().BeEquivalentTo(
+            ["Calcium Nitrate Tetrahydrate", "Magnesium Sulfate Heptahydrate"]);
+    }
+
+    /// <summary>
+    /// The false positive the heuristic must not produce. Monocalcium phosphate carries calcium and
+    /// phosphate in a single soluble compound; flagging it would be wrong on the chemistry and would
+    /// teach users that the warning means nothing.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_SaltCarryingCalciumAndPhosphateInternally_IsNotFlagged()
+    {
+        // Arrange
+        Fertilizer monocalciumPhosphate = new FertilizerBuilder()
+            .AddName("Calcium Monobasic Phosphate")
+            .AddType(ConcentrateType.B)
+            .AddCaNonChelated(15.9).AddP(24.6)
+            .AddWeight(30)
+            .Build();
+        Solution solution = new([monocalciumPhosphate, MonopotassiumPhosphate(20)], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.HasPrecipitationRisk.Should().BeFalse();
+        plan.TankB.Components.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// The same salt still cannot shield a genuine collision: if it sits beside a separate calcium
+    /// source and a separate sulfate, the collision is between those two and must still surface.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_InternallyMixedSaltDoesNotSuppressARealCollision()
+    {
+        // Arrange
+        Fertilizer monocalciumPhosphate = new FertilizerBuilder()
+            .AddName("Calcium Monobasic Phosphate")
+            .AddType(ConcentrateType.A)
+            .AddCaNonChelated(15.9).AddP(24.6)
+            .AddWeight(30)
+            .Build();
+        Fertilizer mislabelledSulfate = new FertilizerBuilder()
+            .AddName("Potassium Sulfate")
+            .AddType(ConcentrateType.A)
+            .AddK(44.87).AddS(18.4)
+            .AddWeight(20)
+            .Build();
+        Solution solution = new(
+            [CalciumNitrate(100), monocalciumPhosphate, mislabelledSulfate],
+            waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.HasPrecipitationRisk.Should().BeTrue();
+        plan.Warnings.Single().Fertilizers.Should().BeEquivalentTo(
+            ["Calcium Nitrate Tetrahydrate", "Potassium Sulfate"]);
+    }
+
+    // ---------------------------------------------------------------- inferred tanks
+
+    /// <summary>
+    /// A custom salt arrives with <see cref="ConcentrateType.None"/> unless its author says otherwise.
+    /// Inferring a tank is useful; inferring it silently is how a user's own sulfate ends up beside
+    /// calcium with nothing to warn them.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_FertilizerWithNoTank_IsInferredAndReported()
+    {
+        // Arrange
+        Fertilizer custom = new FertilizerBuilder()
+            .AddName("My Own Sulfate")
+            .AddK(20).AddS(15)
+            .AddWeight(25)
+            .Build();
+        Solution solution = new([custom], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.TankB.Components.Should().HaveCount(1);
+        ConcentrateWarning warning = plan.Warnings.Single();
+        warning.Kind.Should().Be(ConcentrateWarningKind.TankInferred);
+        warning.Tank.Should().Be(ConcentrateType.B);
+        warning.Fertilizers.Should().BeEquivalentTo(["My Own Sulfate"]);
+    }
+
+    /// <summary>
+    /// A salt with neither calcium nor sulfate nor phosphate is chemically welcome in either tank; it
+    /// lands in A because that is where the convention puts the bulk of the nitrogen.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_UntaggedSaltWithNeitherGroup_GoesToTankA()
+    {
+        // Arrange
+        Fertilizer urea = new FertilizerBuilder()
+            .AddName("Urea")
+            .AddNh2(46.6)
+            .AddWeight(10)
+            .Build();
+        Solution solution = new([urea], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.TankA.Components.Should().HaveCount(1);
+        plan.Warnings.Single().Tank.Should().Be(ConcentrateType.A);
+    }
+
+    // ---------------------------------------------------------------- guards
+
+    /// <summary>
+    /// A "concentrate" at or above working volume concentrates nothing, and a ratio of 1 or less would
+    /// produce a dose of a liter or more per liter. Rejecting it is clearer than returning it.
+    /// </summary>
+    [Theory]
+    [InlineData(100)]
+    [InlineData(200)]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_VolumeNotBelowWorkingVolume_Throws(double concentrateLiters)
+    {
+        // Arrange
+        Solution solution = new([CalciumNitrate(100)], waterLiters: 100);
+
+        // Act
+        Action act = () => solution.AsConcentrate(concentrateLiters);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName(nameof(concentrateLiters));
+    }
+
+    /// <summary>
+    /// Zero or negative volume is a caller bug, not a degenerate concentrate.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_NonPositiveVolume_Throws(double concentrateLiters)
+    {
+        // Arrange
+        Solution solution = new([CalciumNitrate(100)], waterLiters: 100);
+
+        // Act
+        Action act = () => solution.AsConcentrate(concentrateLiters);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName(nameof(concentrateLiters));
+    }
+
+    /// <summary>
+    /// Guards the extension against a null receiver, which a caller can reach through an explicit
+    /// static invocation.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_NullSolution_Throws()
+    {
+        // Act
+        Action act = () => ConcentrateExtensions.AsConcentrate(null!, 1);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/SYT.NPKTools.Tests/ConcentrateTests.cs
+++ b/tests/SYT.NPKTools.Tests/ConcentrateTests.cs
@@ -186,8 +186,8 @@ public class ConcentrateTests
 
         // Assert
         plan.HasPrecipitationRisk.Should().BeTrue();
-        ConcentrateWarning warning = plan.Warnings.Single();
-        warning.Kind.Should().Be(ConcentrateWarningKind.PrecipitationRisk);
+        ConcentrateWarning warning = plan.Warnings
+            .Single(w => w.Kind == ConcentrateWarningKind.PrecipitationRisk);
         warning.Tank.Should().Be(ConcentrateType.A);
         warning.Fertilizers.Should().BeEquivalentTo(
             ["Calcium Nitrate Tetrahydrate", "Magnesium Sulfate Heptahydrate"]);
@@ -249,8 +249,10 @@ public class ConcentrateTests
 
         // Assert
         plan.HasPrecipitationRisk.Should().BeTrue();
-        plan.Warnings.Single().Fertilizers.Should().BeEquivalentTo(
-            ["Calcium Nitrate Tetrahydrate", "Potassium Sulfate"]);
+        plan.Warnings
+            .Single(w => w.Kind == ConcentrateWarningKind.PrecipitationRisk)
+            .Fertilizers.Should().BeEquivalentTo(
+                ["Calcium Nitrate Tetrahydrate", "Potassium Sulfate"]);
     }
 
     // ---------------------------------------------------------------- inferred tanks
@@ -277,8 +279,8 @@ public class ConcentrateTests
 
         // Assert
         plan.TankB.Components.Should().HaveCount(1);
-        ConcentrateWarning warning = plan.Warnings.Single();
-        warning.Kind.Should().Be(ConcentrateWarningKind.TankInferred);
+        ConcentrateWarning warning = plan.Warnings
+            .Single(w => w.Kind == ConcentrateWarningKind.TankInferred);
         warning.Tank.Should().Be(ConcentrateType.B);
         warning.Fertilizers.Should().BeEquivalentTo(["My Own Sulfate"]);
     }
@@ -304,7 +306,9 @@ public class ConcentrateTests
 
         // Assert
         plan.TankA.Components.Should().HaveCount(1);
-        plan.Warnings.Single().Tank.Should().Be(ConcentrateType.A);
+        plan.Warnings
+            .Single(w => w.Kind == ConcentrateWarningKind.TankInferred)
+            .Tank.Should().Be(ConcentrateType.A);
     }
 
     // ---------------------------------------------------------------- guards

--- a/tests/SYT.NPKTools.Tests/ConductivityTests.cs
+++ b/tests/SYT.NPKTools.Tests/ConductivityTests.cs
@@ -1,0 +1,268 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Nutrients;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Covers estimating electrical conductivity from a solution's ions.
+/// </summary>
+/// <remarks>
+/// EC is the one figure in this library that can be checked against an external authority, so the central
+/// tests do exactly that: the certified KCl conductivity standards at 25 °C — 147, 1412 and 12,880 µS/cm
+/// for 0.001, 0.01 and 0.1 M — are the same reference solutions conductivity meters are calibrated
+/// against. Pinning the model's error against them is worth more than any internally consistent assertion,
+/// and it is what stops a future change to the coefficients from passing unnoticed.
+/// </remarks>
+public class ConductivityTests
+{
+    /// <summary>
+    /// Builds a potassium chloride solution at a given molarity, in ppm of each element.
+    /// </summary>
+    private static Ppm PotassiumChloride(double molarity) => new PpmBuilder()
+        .AddK(molarity * 39098)      // mol/L × g/mol × 1000 mg/g
+        .AddCl(molarity * 35450)
+        .AddLiters(100)
+        .Build();
+
+    // ---------------------------------------------------------------- against the standards
+
+    /// <summary>
+    /// The two standards that bracket a real nutrient solution's ionic strength. Within half a percent is
+    /// well inside a meter's own tolerance, and it is the claim the whole feature rests on.
+    /// </summary>
+    [Theory]
+    [InlineData(0.001, 147.0)]
+    [InlineData(0.01, 1412.0)]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_AtTheCertifiedKclStandards_IsWithinHalfAPercent(
+        double molarity,
+        double certifiedMicroSiemens)
+    {
+        // Act
+        ConductivityEstimate result = PotassiumChloride(molarity).EstimateConductivity();
+
+        // Assert
+        double relativeError = result.MicroSiemensPerCm / certifiedMicroSiemens - 1;
+        Math.Abs(relativeError).Should().BeLessThan(0.005);
+    }
+
+    /// <summary>
+    /// The third standard is ten times stronger than any feed, and the model reads about 4% low there. It is
+    /// asserted rather than ignored so the boundary of usefulness is a fact in the test suite instead of a
+    /// claim in a comment.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_WellAboveNutrientStrength_ReadsAboutFourPercentLow()
+    {
+        // Act
+        ConductivityEstimate result = PotassiumChloride(0.1).EstimateConductivity();
+
+        // Assert
+        (result.MicroSiemensPerCm / 12880).Should().BeInRange(0.94, 0.97);
+    }
+
+    /// <summary>
+    /// The uncorrected sum has to stay available and has to be the larger figure, because it is the
+    /// physically exact one at infinite dilution and the correction is the only modelled step. At 0.01 M the
+    /// gap is the 6% by which limiting conductivities overstate a real solution.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_IdealSum_IsAnUpperBoundOnTheEstimate()
+    {
+        // Act
+        ConductivityEstimate result = PotassiumChloride(0.01).EstimateConductivity();
+
+        // Assert
+        result.IdealMicroSiemensPerCm.Should().BeApproximately(1498, 2);
+        result.IdealMicroSiemensPerCm.Should().BeGreaterThan(result.MicroSiemensPerCm);
+        result.Correction.Should().BeInRange(0.94, 0.95);
+    }
+
+    // ---------------------------------------------------------------- ionic strength
+
+    /// <summary>
+    /// Ionic strength is ½Σcz², so a divalent salt has four times the strength per mole its concentration
+    /// suggests. It drives the correction, so getting it wrong would bias every estimate.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_IonicStrength_CountsDivalentIonsFourTimes()
+    {
+        // Arrange — 1 mM of magnesium sulfate: Mg²⁺ and SO₄²⁻, so I = ½(1×4 + 1×4) = 4 mM
+        Ppm magnesiumSulfate = new PpmBuilder()
+            .AddMg(24.305).AddS(32.06)
+            .AddLiters(100)
+            .Build();
+
+        // Act
+        ConductivityEstimate result = magnesiumSulfate.EstimateConductivity();
+
+        // Assert
+        result.IonicStrength.Should().BeApproximately(0.004, 1e-5);
+    }
+
+    /// <summary>
+    /// A working feed sits around 0.02–0.04 M, and the correction near 0.91 is the 9% by which the ideal sum
+    /// overstates it. Both figures are pinned because the docs quote them.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_TypicalFeed_HasTheIonicStrengthAndCorrectionTheDocsQuote()
+    {
+        // Arrange — N150 P50 K210 Ca160 Mg50 S65, the recipe used throughout the documentation
+        Ppm feed = new PpmBuilder()
+            .AddNitrate(150).AddP(50).AddK(210).AddCa(160).AddMg(50).AddS(65)
+            .AddLiters(100)
+            .Build();
+
+        // Act
+        ConductivityEstimate result = feed.EstimateConductivity();
+
+        // Assert
+        result.IonicStrength.Should().BeApproximately(0.025, 0.001);
+        result.Correction.Should().BeApproximately(0.913, 0.005);
+        result.MilliSiemensPerCm.Should().BeApproximately(2.04, 0.05);
+    }
+
+    // ---------------------------------------------------------------- what does not conduct
+
+    /// <summary>
+    /// The case that shows why EC is a poor proxy for feed strength: a solution of urea carries a great deal
+    /// of nitrogen and reads as pure water, because an uncharged molecule cannot carry current.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_NitrogenAsUrea_ReadsAsPureWater()
+    {
+        // Arrange
+        Ppm urea = new PpmBuilder().AddAmine(150).AddLiters(100).Build();
+
+        // Act
+        ConductivityEstimate result = urea.EstimateConductivity();
+
+        // Assert
+        urea.AsMillimolar().Nitrogen.Should().BeApproximately(10.7, 0.1);
+        result.MicroSiemensPerCm.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Micronutrients are excluded from the calculation, matching <see cref="IonBalance"/>. Asserted so the
+    /// omission is deliberate and visible rather than an oversight someone later "fixes" without reading why.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_MicronutrientsAlone_ContributeNothing()
+    {
+        // Arrange
+        Ppm micros = new PpmBuilder()
+            .AddFe(3).AddCu(0.05).AddMn(0.5).AddZn(0.15).AddB(0.5).AddMo(0.05).AddSi(10).AddSe(0.01)
+            .AddLiters(100)
+            .Build();
+
+        // Act
+        ConductivityEstimate result = micros.EstimateConductivity();
+
+        // Assert
+        result.MicroSiemensPerCm.Should().Be(0);
+        result.IonicStrength.Should().Be(0);
+        result.Correction.Should().Be(1, "with no ions there is no interaction to correct for");
+    }
+
+    // ---------------------------------------------------------------- per-ion shares
+
+    /// <summary>
+    /// The shares must add up to the ideal sum, or the breakdown would not be a breakdown. It is what
+    /// answers "what is driving my EC" — usually nitrate, at about a third.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_PerIonShares_SumToTheIdealTotal()
+    {
+        // Arrange
+        Ppm feed = new PpmBuilder()
+            .AddNitrate(150).AddP(50).AddK(210).AddCa(160).AddMg(50).AddS(65).AddNa(20).AddCl(25)
+            .AddLiters(100)
+            .Build();
+
+        // Act
+        ConductivityEstimate result = feed.EstimateConductivity();
+
+        // Assert
+        double sum = result.Potassium + result.Calcium + result.Magnesium + result.Ammonium
+            + result.Sodium + result.Nitrate + result.Phosphate + result.Sulfate + result.Chloride;
+
+        sum.Should().BeApproximately(result.IdealMicroSiemensPerCm, 1e-9);
+        result.Nitrate.Should().BeGreaterThan(result.Phosphate,
+            "a mole of nitrate conducts twice what a mole of dihydrogen phosphate does");
+    }
+
+    /// <summary>
+    /// Identical ppm need not mean identical EC, which is the reason this is computed per ion rather than
+    /// scaled from total dissolved solids. A single factor could not tell these two apart.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_SamePpmDifferentIons_ReadDifferently()
+    {
+        // Arrange — 100 ppm of sulfur against 100 ppm of phosphorus
+        Ppm asSulfate = new PpmBuilder().AddS(100).AddLiters(100).Build();
+        Ppm asPhosphate = new PpmBuilder().AddP(100).AddLiters(100).Build();
+
+        // Act & Assert
+        asSulfate.EstimateConductivity().IdealMicroSiemensPerCm
+            .Should().BeGreaterThan(asPhosphate.EstimateConductivity().IdealMicroSiemensPerCm * 3);
+    }
+
+    // ---------------------------------------------------------------- TDS
+
+    /// <summary>
+    /// A TDS meter measures conductivity and multiplies by a convention, which is why two meters disagree by
+    /// 40% on one solution while both being right. The scale is a parameter for that reason.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsTdsPpm_ScalesTheConductivityByTheMetersOwnConvention()
+    {
+        // Arrange
+        ConductivityEstimate result = PotassiumChloride(0.01).EstimateConductivity();
+
+        // Act & Assert
+        result.AsTdsPpm().Should().BeApproximately(result.MilliSiemensPerCm * 500, 1e-9);
+        result.AsTdsPpm(700).Should().BeApproximately(result.MilliSiemensPerCm * 700, 1e-9);
+        result.AsTdsPpm(700).Should().BeApproximately(result.AsTdsPpm() * 1.4, 1e-6);
+    }
+
+    /// <summary>
+    /// A scale of zero or less would silently produce a meaningless reading.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-500)]
+    [Trait("Category", "Unit")]
+    public void AsTdsPpm_NonPositiveScale_Throws(double scale)
+    {
+        // Arrange
+        ConductivityEstimate result = PotassiumChloride(0.01).EstimateConductivity();
+
+        // Act
+        Action act = () => result.AsTdsPpm(scale);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(scale));
+    }
+
+    /// <summary>
+    /// Guards the entry point.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_NullProfile_Throws()
+    {
+        // Act & Assert
+        ((Action)(() => PpmExtensions.EstimateConductivity(null!)))
+            .Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/SYT.NPKTools.Tests/ConductivityTests.cs
+++ b/tests/SYT.NPKTools.Tests/ConductivityTests.cs
@@ -216,6 +216,95 @@ public class ConductivityTests
             .Should().BeGreaterThan(asPhosphate.EstimateConductivity().IdealMicroSiemensPerCm * 3);
     }
 
+    // ---------------------------------------------------------------- outside the validated range
+
+    /// <summary>
+    /// More salt must always read as more conductivity. The correction was a defect here: left to grow with
+    /// √I it turned the estimate downwards past I ≈ 1.1 and reached exactly zero at I ≈ 3.3, so a strong
+    /// solution reported less conductivity than a weak one and eventually none at all — silently, with no
+    /// NaN and no exception.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_AcrossThreeOrdersOfConcentration_NeverDecreases()
+    {
+        // Arrange
+        double[] molarities = [0.001, 0.01, 0.1, 0.5, 1.0, 2.5, 3.5, 10.0];
+
+        // Act
+        double[] readings = [.. molarities.Select(m =>
+            PotassiumChloride(m).EstimateConductivity().MicroSiemensPerCm)];
+
+        // Assert
+        readings.Should().BeInAscendingOrder();
+        readings.Should().AllSatisfy(r => r.Should().BeGreaterThan(0));
+    }
+
+    /// <summary>
+    /// The case that makes this matter: reading the EC of a concentrate tank rather than the finished feed.
+    /// A working solution at 1:100 sits an order of magnitude past anything the model was anchored on, so the
+    /// flag has to say so — there is no useful number to give there.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_AConcentrateTank_IsReportedAsOutsideTheValidatedRange()
+    {
+        // Arrange — the documentation's feed, and the same feed at concentrate strength
+        Ppm feed = new PpmBuilder()
+            .AddNitrate(150).AddP(50).AddK(210).AddCa(160).AddMg(50).AddS(65)
+            .AddLiters(100)
+            .Build();
+        Ppm concentrate = new PpmBuilder()
+            .AddNitrate(15000).AddP(5000).AddK(21000).AddCa(16000).AddMg(5000).AddS(6500)
+            .AddLiters(100)
+            .Build();
+
+        // Act
+        ConductivityEstimate atWorkingStrength = feed.EstimateConductivity();
+        ConductivityEstimate atTankStrength = concentrate.EstimateConductivity();
+
+        // Assert
+        atWorkingStrength.IsWithinValidatedRange.Should().BeTrue();
+        atTankStrength.IsWithinValidatedRange.Should().BeFalse();
+        atTankStrength.IonicStrength.Should()
+            .BeGreaterThan(ConductivityEstimate.ValidatedIonicStrength * 10);
+    }
+
+    /// <summary>
+    /// The correction stops changing at the top of the anchored range, so it can never reach zero — the value
+    /// that produced an EC of 0 µS/cm for a saturated solution.
+    /// </summary>
+    [Theory]
+    [InlineData(0.5)]
+    [InlineData(3.5)]
+    [InlineData(50.0)]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_FarOutsideTheRange_KeepsTheCorrectionFrozenRatherThanZero(double molarity)
+    {
+        // Act
+        ConductivityEstimate result = PotassiumChloride(molarity).EstimateConductivity();
+
+        // Assert — the correction at I = 0.1, held constant above it
+        result.Correction.Should().BeApproximately(1 - 0.55 * Math.Sqrt(0.1), 1e-9);
+        result.MicroSiemensPerCm.Should().BeGreaterThan(0);
+        result.IsWithinValidatedRange.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Freezing the correction must not disturb the anchored range, which is where every real solution lives
+    /// and where the model's accuracy claims come from.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_InsideTheRange_IsUnaffectedByTheClamp()
+    {
+        // Act & Assert — the two certified standards that bracket a real feed, unchanged
+        (PotassiumChloride(0.001).EstimateConductivity().MicroSiemensPerCm / 147).Should()
+            .BeApproximately(1, 0.005);
+        (PotassiumChloride(0.01).EstimateConductivity().MicroSiemensPerCm / 1412).Should()
+            .BeApproximately(1, 0.005);
+    }
+
     // ---------------------------------------------------------------- TDS
 
     /// <summary>

--- a/tests/SYT.NPKTools.Tests/FertilizerBundleGeneratorTests.cs
+++ b/tests/SYT.NPKTools.Tests/FertilizerBundleGeneratorTests.cs
@@ -1,0 +1,333 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Fertilizers;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Covers generating optimization bundles from a caller's own salts.
+/// </summary>
+/// <remarks>
+/// The shape being pinned is hold-one-out: everything on the shelf, then the shelf minus each salt. It
+/// was chosen by measurement rather than taste — against the hand-written catalogue on three macro
+/// targets it returned more distinct recipes — so the tests fix the structure that measurement picked,
+/// and the reporting that keeps a short answer from looking like a complete one.
+/// </remarks>
+public class FertilizerBundleGeneratorTests
+{
+    private static Fertilizer Salt(
+        string name,
+        double n = 0,
+        double p = 0,
+        double k = 0,
+        double ca = 0,
+        double mg = 0,
+        double s = 0,
+        double fe = 0,
+        double na = 0,
+        double cl = 0) =>
+        new FertilizerBuilder()
+            .AddName(name)
+            .AddNo3(n).AddP(p).AddK(k).AddCaNonChelated(ca).AddMgNonChelated(mg).AddS(s)
+            .AddFeNonChelated(fe).AddNa(na).AddCl(cl)
+            .Build();
+
+    private static Fertilizer[] Shelf() =>
+    [
+        Salt("Calcium Nitrate", n: 11.86, ca: 16.97),
+        Salt("Potassium Nitrate", n: 13.85, k: 38.67),
+        Salt("Magnesium Sulfate", mg: 9.86, s: 13.01),
+        Salt("Monopotassium Phosphate", p: 22.76, k: 28.73),
+    ];
+
+    // ---------------------------------------------------------------- structure
+
+    /// <summary>
+    /// The generated shape is one bundle per salt plus one holding everything. Alternatives can only come
+    /// from taking a salt away: every superset of the best mix yields that same mix again, so a bundle
+    /// list that only grew would be one recipe repeated.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GenerateMacro_ProducesTheFullShelfPlusOneBundlePerSaltHeldOut()
+    {
+        // Arrange
+        Fertilizer[] shelf = Shelf();
+
+        // Act
+        GeneratedBundles result = FertilizerBundleGenerator.GenerateMacro(shelf);
+
+        // Assert
+        result.Bundles.Should().HaveCount(shelf.Length + 1);
+        result.Bundles[0].Should().HaveCount(shelf.Length);
+        result.Bundles.Skip(1).Should().AllSatisfy(bundle => bundle.Should().HaveCount(shelf.Length - 1));
+    }
+
+    /// <summary>
+    /// Every salt must be the one held out exactly once, otherwise some alternative recipe is silently
+    /// unavailable. This is also what lets a caller label a bundle "without the MKP" by set difference
+    /// against the first.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GenerateMacro_HoldsOutEachSaltExactlyOnce()
+    {
+        // Arrange
+        Fertilizer[] shelf = Shelf();
+
+        // Act
+        GeneratedBundles result = FertilizerBundleGenerator.GenerateMacro(shelf);
+
+        // Assert
+        IEnumerable<string> heldOut = result.Bundles
+            .Skip(1)
+            .Select(bundle => result.Bundles[0].Except(bundle).Single().Name.Value);
+
+        heldOut.Should().BeEquivalentTo(shelf.Select(f => f.Name.Value));
+    }
+
+    /// <summary>
+    /// Order in, order out: a caller who lists their salts differently must get the same bundles, or two
+    /// runs of the same shelf would disagree about which recipes exist.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GenerateMacro_IsIndependentOfTheOrderSaltsAreSuppliedIn()
+    {
+        // Arrange
+        Fertilizer[] shelf = Shelf();
+        Fertilizer[] reversed = [.. shelf.Reverse()];
+
+        // Act
+        GeneratedBundles first = FertilizerBundleGenerator.GenerateMacro(shelf);
+        GeneratedBundles second = FertilizerBundleGenerator.GenerateMacro(reversed);
+
+        // Assert
+        first.Bundles.Select(b => b.Select(f => f.Name.Value))
+            .Should().BeEquivalentTo(
+                second.Bundles.Select(b => b.Select(f => f.Name.Value)),
+                options => options.WithStrictOrdering());
+    }
+
+    /// <summary>
+    /// One salt cannot be reduced any further, so it yields the one bundle it is — not an empty second
+    /// bundle that could never solve anything.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GenerateMacro_SingleSalt_ProducesOneBundle()
+    {
+        // Act
+        GeneratedBundles result = FertilizerBundleGenerator.GenerateMacro([Salt("Potassium Nitrate", n: 13.85, k: 38.67)]);
+
+        // Assert
+        result.Bundles.Should().HaveCount(1);
+        result.Bundles[0].Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// The same salt listed twice is one salt. Left in, it would become two identical columns in the
+    /// linear program and the recipe would list it twice.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GenerateMacro_DuplicateSalts_AreCountedOnce()
+    {
+        // Arrange
+        Fertilizer[] shelf =
+        [
+            Salt("Potassium Nitrate", n: 13.85, k: 38.67),
+            Salt("potassium nitrate", n: 13.85, k: 38.67),
+        ];
+
+        // Act
+        GeneratedBundles result = FertilizerBundleGenerator.GenerateMacro(shelf);
+
+        // Assert
+        result.Bundles.Should().HaveCount(1);
+        result.Bundles[0].Should().HaveCount(1);
+    }
+
+    // ---------------------------------------------------------------- tier split
+
+    /// <summary>
+    /// A salt carrying a micronutrient belongs to the micro tier even when it also carries a macro
+    /// element. Iron sulfate's sulfur is incidental: dosing it to meet a sulfur target would mean iron at
+    /// a hundred times the intended rate.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Generate_IronSulfate_IsAMicroSaltDespiteItsSulfur()
+    {
+        // Arrange
+        Fertilizer ironSulfate = Salt("Iron Sulfate", fe: 20.09, s: 11.53);
+        Fertilizer[] shelf = [.. Shelf(), ironSulfate];
+
+        // Act
+        GeneratedBundles macro = FertilizerBundleGenerator.GenerateMacro(shelf);
+        GeneratedBundles micro = FertilizerBundleGenerator.GenerateMicro(shelf);
+
+        // Assert
+        FertilizerBundleGenerator.IsMicro(ironSulfate).Should().BeTrue();
+        macro.Bundles[0].Should().NotContain(ironSulfate);
+        micro.Bundles[0].Should().Contain(ironSulfate);
+    }
+
+    /// <summary>
+    /// A shelf holding nothing this tier can use produces no bundles rather than one empty bundle, which
+    /// the optimizer would spend a solve on for nothing.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GenerateMicro_ShelfOfOnlyMacroSalts_ProducesNothing()
+    {
+        // Act
+        GeneratedBundles result = FertilizerBundleGenerator.GenerateMicro(Shelf());
+
+        // Assert
+        result.Bundles.Should().BeEmpty();
+        result.Should().Be(GeneratedBundles.Empty);
+    }
+
+    // ---------------------------------------------------------------- reporting
+
+    /// <summary>
+    /// An element nothing on the shelf supplies is the difference between "no solutions" and "you have no
+    /// magnesium source". Returning the former and leaving the caller to work out the latter is the
+    /// failure this reporting exists to prevent.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GenerateMacro_ElementNoSaltSupplies_IsReportedAsUncovered()
+    {
+        // Arrange — no magnesium and no sulfur anywhere on the shelf
+        Fertilizer[] shelf =
+        [
+            Salt("Calcium Nitrate", n: 11.86, ca: 16.97),
+            Salt("Monopotassium Phosphate", p: 22.76, k: 28.73),
+        ];
+
+        // Act
+        GeneratedBundles result = FertilizerBundleGenerator.GenerateMacro(shelf);
+
+        // Assert
+        result.UncoveredElements.Should().BeEquivalentTo(["Mg", "S"]);
+        result.IsComplete.Should().BeFalse();
+        result.Bundles.Should().NotBeEmpty("the elements that are covered can still be met");
+    }
+
+    /// <summary>
+    /// A shelf that covers everything reports nothing outstanding, so <c>IsComplete</c> is usable as the
+    /// single check a caller makes.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GenerateMacro_ShelfCoveringEveryElement_IsComplete()
+    {
+        // Act
+        GeneratedBundles result = FertilizerBundleGenerator.GenerateMacro(Shelf());
+
+        // Assert
+        result.UncoveredElements.Should().BeEmpty();
+        result.BundlesDropped.Should().Be(0);
+        result.IsComplete.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Hitting the count limit must be visible. A truncated list that reported nothing would read as
+    /// "these are all the options" when it was not.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GenerateMacro_MoreBundlesThanTheLimit_ReportsWhatWasDropped()
+    {
+        // Arrange
+        BundleGenerationSettings settings = new() { MaxBundles = 3 };
+
+        // Act
+        GeneratedBundles result = FertilizerBundleGenerator.GenerateMacro(Shelf(), settings);
+
+        // Assert
+        result.Bundles.Should().HaveCount(3);
+        result.BundlesDropped.Should().Be(2, "four salts yield five bundles, of which three were kept");
+        result.IsComplete.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A salt of nothing but sodium and chloride is real, but there is no target it helps meet. Left
+    /// unreported it would look included and every recipe would read as though it had been considered.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Repository_SaltCarryingNoTargetableElement_IsReportedAsUnusable()
+    {
+        // Arrange
+        Fertilizer[] shelf = [.. Shelf(), Salt("Sodium Chloride", na: 39.34, cl: 60.66)];
+
+        // Act
+        CustomFertilizerBundleRepository repository = new(shelf);
+
+        // Assert
+        repository.UnusableSalts.Should().BeEquivalentTo(["Sodium Chloride"]);
+        repository.Macro()[0].Select(f => f.Name.Value).Should().NotContain("Sodium Chloride");
+    }
+
+    // ---------------------------------------------------------------- guards
+
+    /// <summary>
+    /// A limit of zero would mean no bundles at all, which is a caller bug rather than a valid request.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [Trait("Category", "Unit")]
+    public void GenerateMacro_NonPositiveBundleLimit_Throws(int maxBundles)
+    {
+        // Arrange
+        BundleGenerationSettings settings = new() { MaxBundles = maxBundles };
+
+        // Act
+        Action act = () => FertilizerBundleGenerator.GenerateMacro(Shelf(), settings);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName(nameof(BundleGenerationSettings.MaxBundles));
+    }
+
+    /// <summary>
+    /// Guards the null cases on every public entry point.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Generate_NullArguments_Throw()
+    {
+        // Act & Assert
+        ((Action)(() => FertilizerBundleGenerator.GenerateMacro(null!)))
+            .Should().Throw<ArgumentNullException>();
+        ((Action)(() => FertilizerBundleGenerator.GenerateMicro(null!)))
+            .Should().Throw<ArgumentNullException>();
+        ((Action)(() => FertilizerBundleGenerator.IsMicro(null!)))
+            .Should().Throw<ArgumentNullException>();
+        ((Action)(() => FertilizerBundleGenerator.IsUsable(null!)))
+            .Should().Throw<ArgumentNullException>();
+        ((Action)(() => new CustomFertilizerBundleRepository(null!)))
+            .Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// An empty shelf is not an error — a caller may be building a list up — but it must not produce a
+    /// bundle of nothing.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Generate_EmptyShelf_ProducesNothing()
+    {
+        // Act
+        CustomFertilizerBundleRepository repository = new([]);
+
+        // Assert
+        repository.Macro().Should().BeEmpty();
+        repository.Micro().Should().BeEmpty();
+        repository.UnusableSalts.Should().BeEmpty();
+    }
+}

--- a/tests/SYT.NPKTools.Tests/MolarAndIonBalanceTests.cs
+++ b/tests/SYT.NPKTools.Tests/MolarAndIonBalanceTests.cs
@@ -1,0 +1,288 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Fertilizers;
+using SYT.NPKTools.Nutrients;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Covers millimolar conversion and the milliequivalent charge balance.
+/// </summary>
+/// <remarks>
+/// Two claims are being pinned. The first is arithmetic: ppm divided by atomic weight, which matters
+/// because every published formulation is stated in mM and a recipe read off a paper table has to be
+/// converted before it can be used. The second is chemical and less obvious — the gap between cations and
+/// anions is not an error but the acid or base the recipe itself contributes, so the tests assert it comes
+/// out at zero for neutral salts and at exactly one proton per phosphorus for the acid and basic ones.
+/// </remarks>
+public class MolarAndIonBalanceTests
+{
+    private const double Precision = 1e-6;
+
+    // ---------------------------------------------------------------- millimolar
+
+    /// <summary>
+    /// One atomic weight in ppm is one millimole per litre, by definition. Checking three elements of
+    /// very different weight pins the table as well as the arithmetic.
+    /// </summary>
+    [Theory]
+    [InlineData(39.098, 1.0)]
+    [InlineData(78.196, 2.0)]
+    [InlineData(19.549, 0.5)]
+    [Trait("Category", "Unit")]
+    public void AsMillimolar_PotassiumAtItsAtomicWeight_IsOneMillimolePerAtomicWeight(
+        double ppmValue,
+        double expectedMillimolar)
+    {
+        // Arrange
+        Ppm ppm = new PpmBuilder().AddK(ppmValue).AddLiters(100).Build();
+
+        // Act
+        MolarProfile result = ppm.AsMillimolar();
+
+        // Assert
+        result.Potassium.Should().BeApproximately(expectedMillimolar, 1e-4);
+    }
+
+    /// <summary>
+    /// The reason mM exists in this library: equal ppm of calcium and magnesium are not equal amounts of
+    /// anything. Magnesium's lower atomic weight means two-thirds again as many ions, and a grower reading
+    /// only ppm cannot see that.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsMillimolar_EqualPpmOfCalciumAndMagnesium_AreNotEqualMillimolar()
+    {
+        // Arrange
+        Ppm ppm = new PpmBuilder().AddCa(40).AddMg(40).AddLiters(100).Build();
+
+        // Act
+        MolarProfile result = ppm.AsMillimolar();
+
+        // Assert
+        result.Calcium.Should().BeApproximately(0.998, 0.001);
+        result.Magnesium.Should().BeApproximately(1.646, 0.001);
+    }
+
+    /// <summary>
+    /// The nitrogen forms convert separately and still sum to the total, because urea and nitrate behave
+    /// differently and the difference is lost if only the total is carried across.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsMillimolar_KeepsTheThreeNitrogenFormsAndSumsThem()
+    {
+        // Arrange
+        Ppm ppm = new PpmBuilder().AddNitrate(140).AddAmmonium(14.007).AddAmine(28.014).AddLiters(100).Build();
+
+        // Act
+        MolarProfile result = ppm.AsMillimolar();
+
+        // Assert
+        result.Ammonium.Should().BeApproximately(1.0, 1e-4);
+        result.Amine.Should().BeApproximately(2.0, 1e-4);
+        result.Nitrogen.Should().BeApproximately(
+            result.Nitrate + result.Ammonium + result.Amine, Precision);
+    }
+
+    // ---------------------------------------------------------------- milliequivalents
+
+    /// <summary>
+    /// Milliequivalents are millimoles times charge, so a divalent ion counts twice. This is why a
+    /// solution table in meq looks nothing like the same table in mM.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IonBalance_DivalentIonsCountTwice()
+    {
+        // Arrange — one millimole each of a monovalent and two divalent cations
+        Ppm ppm = new PpmBuilder()
+            .AddK(39.098).AddCa(40.078).AddMg(24.305)
+            .AddLiters(100)
+            .Build();
+
+        // Act
+        IonBalance result = ppm.IonBalance();
+
+        // Assert
+        result.Potassium.Should().BeApproximately(1.0, 1e-4);
+        result.Calcium.Should().BeApproximately(2.0, 1e-4);
+        result.Magnesium.Should().BeApproximately(2.0, 1e-4);
+    }
+
+    /// <summary>
+    /// Urea is a neutral molecule. It supplies nitrogen, so it must show up in mM, and it carries no
+    /// charge, so it must not show up in meq — which is also the reason it does nothing for a plant's
+    /// cation-anion uptake balance.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IonBalance_Urea_CountsAsNitrogenButNotAsCharge()
+    {
+        // Arrange
+        Ppm ppm = new PpmBuilder().AddAmine(46.6).AddLiters(100).Build();
+
+        // Act
+        MolarProfile molar = ppm.AsMillimolar();
+        IonBalance ions = ppm.IonBalance();
+
+        // Assert
+        molar.Amine.Should().BeGreaterThan(0);
+        ions.Total.Should().Be(0);
+        ions.AcidEquivalents.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Boron and silicon are undissociated acids at nutrient-solution pH, so they carry no charge at all.
+    /// Micronutrients are excluded for a softer reason — their speciation is ambiguous and their
+    /// contribution is under 0.1 meq/L — but the effect is the same and both are asserted here so a later
+    /// change to include them cannot happen silently.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IonBalance_MicronutrientsBoronAndSilicon_ContributeNoCharge()
+    {
+        // Arrange
+        Ppm ppm = new PpmBuilder()
+            .AddB(0.5).AddSi(10).AddFe(3).AddCu(0.05).AddMn(0.5).AddZn(0.15).AddMo(0.05).AddSe(0.01)
+            .AddLiters(100)
+            .Build();
+
+        // Act
+        IonBalance result = ppm.IonBalance();
+
+        // Assert
+        result.Total.Should().Be(0);
+    }
+
+    /// <summary>
+    /// An empty profile must not divide by zero. A caller building a target up from nothing hits this.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IonBalance_EmptyProfile_IsNeutralWithoutDividingByZero()
+    {
+        // Arrange
+        Ppm ppm = new PpmBuilder().AddLiters(100).Build();
+
+        // Act
+        IonBalance result = ppm.IonBalance();
+
+        // Assert
+        result.RelativeDifference.Should().Be(0);
+        result.IsChargeNeutral.Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------- acid-base character
+
+    /// <summary>
+    /// Neutral salts balance exactly, and the profile has to be derived from real salts for the claim to
+    /// mean anything — an invented set of round ppm figures corresponds to no salt combination at all and
+    /// would balance or not by accident. Monopotassium phosphate is the case worth naming: K⁺ against
+    /// H₂PO₄⁻, one charge each, which is why it is the phosphorus source that does not move pH.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IonBalance_ProfileMixedFromNeutralSalts_BalancesExactly()
+    {
+        // Arrange
+        Fertilizer[] neutralSalts =
+        [
+            new FertilizerBuilder().AddName("Calcium Nitrate Tetrahydrate")
+                .AddNo3(11.86).AddCaNonChelated(16.97).AddWeight(88).Build(),
+            new FertilizerBuilder().AddName("Potassium Nitrate")
+                .AddNo3(13.85).AddK(38.67).AddWeight(38).Build(),
+            new FertilizerBuilder().AddName("Magnesium Sulfate Heptahydrate")
+                .AddMgNonChelated(9.86).AddS(13.01).AddWeight(51).Build(),
+            new FertilizerBuilder().AddName("Monopotassium Phosphate")
+                .AddP(22.76).AddK(28.73).AddWeight(22).Build(),
+        ];
+
+        // Act
+        Ppm ppm = NpkTools.CreatePpmCalculator().CalculatePpm(neutralSalts, waterLiters: 100);
+        IonBalance result = ppm.IonBalance();
+
+        // Assert
+        result.Cations.Should().BeGreaterThan(10, "the mix is a realistic working strength");
+        result.AcidEquivalents.Should().BeApproximately(0, 0.01);
+        result.IsChargeNeutral.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Phosphoric acid supplies H₂PO₄⁻ with a proton rather than a metal, so it shows an anion surplus of
+    /// exactly one per phosphorus — which is the H⁺ it releases. This is the number that says how much
+    /// less pH-down a recipe needs.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IonBalance_PhosphoricAcid_ReleasesOneProtonPerPhosphorus()
+    {
+        // Arrange
+        Ppm ppm = new PpmBuilder().AddP(31.0).AddLiters(100).Build();
+        double phosphorusMillimolar = ppm.AsMillimolar().Phosphorus;
+
+        // Act
+        IonBalance result = ppm.IonBalance();
+
+        // Assert
+        result.Cations.Should().Be(0);
+        result.AcidEquivalents.Should().BeApproximately(phosphorusMillimolar, Precision);
+        result.IsChargeNeutral.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Dipotassium phosphate is the mirror image: two K⁺ against an HPO₄²⁻ that takes up a proton on its
+    /// way to H₂PO₄⁻ at working pH. The cation surplus of one per phosphorus is the H⁺ it consumes, so it
+    /// pushes pH up rather than down.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IonBalance_DipotassiumPhosphate_ConsumesOneProtonPerPhosphorus()
+    {
+        // Arrange — K₂HPO₄ is 17.8% P and 44.9% K, so 100 ppm of the salt in these proportions
+        Ppm ppm = new PpmBuilder().AddP(17.8).AddK(44.9).AddLiters(100).Build();
+        double phosphorusMillimolar = ppm.AsMillimolar().Phosphorus;
+
+        // Act
+        IonBalance result = ppm.IonBalance();
+
+        // Assert — negative acidity: the salt is a base
+        result.AcidEquivalents.Should().BeApproximately(-phosphorusMillimolar, 0.01);
+        result.IsChargeNeutral.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The relative figure is what makes the same threshold meaningful for a seedling feed and a
+    /// full-strength recipe, so it must scale with concentration while the flag does not move.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IonBalance_RelativeDifference_IsIndependentOfStrength()
+    {
+        // Arrange
+        Ppm weak = new PpmBuilder().AddP(17.8).AddK(44.9).AddLiters(100).Build();
+        Ppm strong = new PpmBuilder().AddP(35.6).AddK(89.8).AddLiters(100).Build();
+
+        // Act
+        IonBalance weakBalance = weak.IonBalance();
+        IonBalance strongBalance = strong.IonBalance();
+
+        // Assert
+        strongBalance.Total.Should().BeApproximately(weakBalance.Total * 2, 1e-6);
+        strongBalance.RelativeDifference.Should().BeApproximately(weakBalance.RelativeDifference, 1e-9);
+    }
+
+    // ---------------------------------------------------------------- guards
+
+    /// <summary>
+    /// Guards both extension methods against a null receiver.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Conversions_NullProfile_Throw()
+    {
+        // Act & Assert
+        ((Action)(() => PpmExtensions.AsMillimolar(null!))).Should().Throw<ArgumentNullException>();
+        ((Action)(() => PpmExtensions.IonBalance(null!))).Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/SYT.NPKTools.Tests/NutrientRatiosTests.cs
+++ b/tests/SYT.NPKTools.Tests/NutrientRatiosTests.cs
@@ -1,0 +1,181 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Nutrients;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Covers the ratio analysis and the per-fertilizer breakdown.
+/// </summary>
+/// <remarks>
+/// These close the standing complaint about comparable tools — that they compute a recipe but say
+/// nothing about whether it is a sensible one.
+/// </remarks>
+public class NutrientRatiosTests
+{
+    private const double Precision = 1e-9;
+
+    // ---------------------------------------------------------------- ratios
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Ratios_AreComputedAsPartsOfTheFirstPerOneOfTheSecond()
+    {
+        // Arrange: N 150 (all nitrate), P 50, K 200, Ca 100, Mg 50, S 60.
+        Ppm ppm = new PpmBuilder()
+            .AddNitrate(150).AddP(50).AddK(200).AddCa(100).AddMg(50).AddS(60).AddLiters(100)
+            .Build();
+
+        // Act
+        NutrientRatios ratios = ppm.Ratios();
+
+        // Assert
+        ratios.NitrogenToPotassium.Should().BeApproximately(150.0 / 200, Precision);
+        ratios.PotassiumToCalcium.Should().BeApproximately(2, Precision);
+        ratios.CalciumToMagnesium.Should().BeApproximately(2, Precision);
+        ratios.PotassiumToMagnesium.Should().BeApproximately(4, Precision);
+        ratios.NitrogenToSulfur.Should().BeApproximately(2.5, Precision);
+        ratios.NitrogenToPhosphorus.Should().BeApproximately(3, Precision);
+    }
+
+    /// <summary>
+    /// The nitrate-to-ammonium ratio is the one that predicts pH movement rather than nutrition, so it
+    /// is asserted separately including its total-nitrogen interaction.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Ratios_NitrateToAmmonium_UsesTheNitrogenForms()
+    {
+        // Arrange: 120 nitrate + 30 ammonium = 150 total nitrogen.
+        Ppm ppm = new PpmBuilder()
+            .AddNitrate(120).AddAmmonium(30).AddK(200).AddLiters(100)
+            .Build();
+
+        // Act
+        NutrientRatios ratios = ppm.Ratios();
+
+        // Assert
+        ratios.NitrateToAmmonium.Should().BeApproximately(4, Precision);
+        ratios.NitrogenToPotassium.Should().BeApproximately(150.0 / 200, Precision);
+    }
+
+    /// <summary>
+    /// A ratio with nothing in its denominator is null, not zero and not infinity. A nitrate-only mix is
+    /// the everyday case, and reporting "0" or "∞" for it would be actively misleading.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Ratios_MissingDenominator_IsNullRatherThanZeroOrInfinity()
+    {
+        // Arrange: no ammonium, no magnesium, no sulfur.
+        Ppm ppm = new PpmBuilder().AddNitrate(150).AddK(200).AddLiters(100).Build();
+
+        // Act
+        NutrientRatios ratios = ppm.Ratios();
+
+        // Assert
+        ratios.NitrateToAmmonium.Should().BeNull();
+        ratios.CalciumToMagnesium.Should().BeNull();
+        ratios.PotassiumToMagnesium.Should().BeNull();
+        ratios.NitrogenToSulfur.Should().BeNull();
+        ratios.NitrogenToPhosphorus.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Ratios_TotalPpm_MatchesTheSolutionTotal()
+    {
+        Ppm ppm = new PpmBuilder()
+            .AddNitrate(150).AddP(50).AddK(200).AddLiters(100)
+            .Build();
+
+        ppm.Ratios().TotalPpm.Should().BeApproximately(ppm.Value, Precision);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Ratios_NullPpm_ThrowsArgumentNullException()
+    {
+        Action act = () => ((Ppm)null!).Ratios();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // ---------------------------------------------------------------- breakdown
+
+    /// <summary>
+    /// The parts must sum to the whole. Measured through the same calculator as the total, so a change
+    /// to the ppm arithmetic cannot make them disagree.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Breakdown_ContributionsSumToTheWholeMix()
+    {
+        // Arrange
+        IFertilizerOptimizationService service = NpkTools.CreateOptimizationService();
+        IPpmCalculationService calculator = NpkTools.CreatePpmCalculator();
+        PpmTarget target = new PpmTargetBuilder()
+            .AddN(150).AddP(50).AddK(200).AddCa(100).AddMg(50).AddLiters(100)
+            .Build();
+
+        Solution mix = service.FindMacroSolutions(target)[0];
+        Ppm whole = calculator.CalculatePpm(mix, mix.WaterLiters);
+
+        // Act
+        IReadOnlyList<FertilizerContribution> parts = mix.Breakdown(calculator);
+
+        // Assert
+        parts.Should().HaveCount(mix.Count);
+        parts.Sum(p => p.Contribution.Nitrogen.Value).Should().BeApproximately(whole.Nitrogen.Value, 1e-6);
+        parts.Sum(p => p.Contribution.Potassium.Value).Should().BeApproximately(whole.Potassium.Value, 1e-6);
+        parts.Sum(p => p.Contribution.Calcium.Value).Should().BeApproximately(whole.Calcium.Value, 1e-6);
+        parts.Sum(p => p.Contribution.Sulfur.Value).Should().BeApproximately(whole.Sulfur.Value, 1e-6);
+    }
+
+    /// <summary>
+    /// The point of the breakdown: attributing an element nobody asked for to the salt that carried it.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Breakdown_AttributesAnUnrequestedElementToItsSource()
+    {
+        // Arrange: the target says nothing about sulfur, but magnesium sulfate brings it along.
+        IFertilizerOptimizationService service = NpkTools.CreateOptimizationService();
+        IPpmCalculationService calculator = NpkTools.CreatePpmCalculator();
+        PpmTarget target = new PpmTargetBuilder()
+            .AddN(150).AddP(50).AddK(200).AddCa(100).AddMg(50).AddLiters(100)
+            .Build();
+
+        Solution mix = service.FindMacroSolutions(target)[0];
+
+        // Act
+        IReadOnlyList<FertilizerContribution> parts = mix.Breakdown(calculator);
+        FertilizerContribution[] sulfurSources =
+            [.. parts.Where(p => p.Contribution.Sulfur.Value > 0)];
+
+        // Assert: sulfur arrived, and it is traceable to specific salts rather than being anonymous.
+        calculator.CalculatePpm(mix, mix.WaterLiters).Sulfur.Value.Should().BeGreaterThan(0);
+        sulfurSources.Should().NotBeEmpty();
+        sulfurSources.Should().AllSatisfy(p => p.Fertilizer.Name.Value.Should().NotBeEmpty());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Breakdown_NullCalculator_ThrowsArgumentNullException()
+    {
+        Solution mix = new([], 100);
+
+        Action act = () => mix.Breakdown(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Breakdown_NullSolution_ThrowsArgumentNullException()
+    {
+        Action act = () => ((Solution)null!).Breakdown(NpkTools.CreatePpmCalculator());
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/SYT.NPKTools.Tests/ReferenceDataTests.cs
+++ b/tests/SYT.NPKTools.Tests/ReferenceDataTests.cs
@@ -1,0 +1,227 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Nutrients;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Pins the physical constants the library computes from, against published values.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The constants themselves are internal, so these tests reach them the way a caller would — through the
+/// conversion that uses them. One atomic weight in ppm is one millimole per litre by definition, and one
+/// millimole of an ion times its molar conductivity is that ion's µS/cm, so each constant can be read back
+/// out of a single-element profile and compared with its reference value.
+/// </para>
+/// <para>
+/// Worth pinning because these are the numbers no test would otherwise notice being wrong. A mistaken atomic
+/// weight shifts every mM and meq figure by a few percent and nothing fails; a mistaken molar conductivity
+/// moves EC in a way that looks like ordinary model error. All were verified against published tables — the
+/// IUPAC standard atomic weights, and the CRC "Ionic Conductivity and Diffusion at Infinite Dilution" table
+/// cross-checked against a second compilation. H₂PO₄⁻ is the one with real spread in the literature (31.8 to
+/// 36 depending on the source), which matters little: phosphate is about 2% of a feed's conductivity, so the
+/// whole spread moves total EC by under half a percent.
+/// </para>
+/// </remarks>
+public class ReferenceDataTests
+{
+    // ---------------------------------------------------------------- atomic weights
+
+    /// <summary>
+    /// One atomic weight in ppm is one millimole per litre. Reading the constant back out this way pins it
+    /// against the IUPAC standard atomic weights without exposing the internal table.
+    /// </summary>
+    [Theory]
+    [InlineData("N", 14.007)]
+    [InlineData("P", 30.974)]
+    [InlineData("K", 39.098)]
+    [InlineData("Ca", 40.078)]
+    [InlineData("Mg", 24.305)]
+    [InlineData("S", 32.06)]
+    [InlineData("Fe", 55.845)]
+    [InlineData("Cu", 63.546)]
+    [InlineData("Mn", 54.938)]
+    [InlineData("Zn", 65.38)]
+    [InlineData("B", 10.81)]
+    [InlineData("Mo", 95.95)]
+    [InlineData("Cl", 35.45)]
+    [InlineData("Si", 28.085)]
+    [InlineData("Se", 78.971)]
+    [InlineData("Na", 22.990)]
+    [Trait("Category", "Unit")]
+    public void AsMillimolar_OneAtomicWeightInPpm_IsExactlyOneMillimolar(string element, double atomicWeight)
+    {
+        // Arrange
+        PpmBuilder builder = new();
+        builder = element switch
+        {
+            "N" => builder.AddNitrate(atomicWeight),
+            "P" => builder.AddP(atomicWeight),
+            "K" => builder.AddK(atomicWeight),
+            "Ca" => builder.AddCa(atomicWeight),
+            "Mg" => builder.AddMg(atomicWeight),
+            "S" => builder.AddS(atomicWeight),
+            "Fe" => builder.AddFe(atomicWeight),
+            "Cu" => builder.AddCu(atomicWeight),
+            "Mn" => builder.AddMn(atomicWeight),
+            "Zn" => builder.AddZn(atomicWeight),
+            "B" => builder.AddB(atomicWeight),
+            "Mo" => builder.AddMo(atomicWeight),
+            "Cl" => builder.AddCl(atomicWeight),
+            "Si" => builder.AddSi(atomicWeight),
+            "Se" => builder.AddSe(atomicWeight),
+            _ => builder.AddNa(atomicWeight),
+        };
+
+        MolarProfile molar = builder.AddLiters(100).Build().AsMillimolar();
+
+        // Act
+        double millimolar = element switch
+        {
+            "N" => molar.Nitrate,
+            "P" => molar.Phosphorus,
+            "K" => molar.Potassium,
+            "Ca" => molar.Calcium,
+            "Mg" => molar.Magnesium,
+            "S" => molar.Sulfur,
+            "Fe" => molar.Iron,
+            "Cu" => molar.Copper,
+            "Mn" => molar.Manganese,
+            "Zn" => molar.Zinc,
+            "B" => molar.Boron,
+            "Mo" => molar.Molybdenum,
+            "Cl" => molar.Chlorine,
+            "Si" => molar.Silicon,
+            "Se" => molar.Selenium,
+            _ => molar.Sodium,
+        };
+
+        // Assert
+        millimolar.Should().BeApproximately(1.0, 1e-12);
+    }
+
+    // ---------------------------------------------------------------- molar conductivities
+
+    /// <summary>
+    /// One millimole of an ion contributes its molar conductivity in µS/cm, so the constants read back out of
+    /// a single-ion profile. Compared against the CRC infinite-dilution table.
+    /// </summary>
+    [Theory]
+    [InlineData("K", 39.098, 73.5)]
+    [InlineData("Na", 22.990, 50.1)]
+    [InlineData("Ca", 40.078, 119.0)]
+    [InlineData("Mg", 24.305, 106.0)]
+    [InlineData("Cl", 35.45, 76.3)]
+    [InlineData("S", 32.06, 160.0)]
+    [InlineData("P", 30.974, 36.0)]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_OneMillimolarIon_ContributesItsMolarConductivity(
+        string element,
+        double atomicWeight,
+        double expectedMicroSiemens)
+    {
+        // Arrange
+        PpmBuilder builder = new();
+        builder = element switch
+        {
+            "K" => builder.AddK(atomicWeight),
+            "Na" => builder.AddNa(atomicWeight),
+            "Ca" => builder.AddCa(atomicWeight),
+            "Mg" => builder.AddMg(atomicWeight),
+            "Cl" => builder.AddCl(atomicWeight),
+            "S" => builder.AddS(atomicWeight),
+            _ => builder.AddP(atomicWeight),
+        };
+
+        ConductivityEstimate estimate = builder.AddLiters(100).Build().EstimateConductivity();
+
+        // Act
+        double contribution = element switch
+        {
+            "K" => estimate.Potassium,
+            "Na" => estimate.Sodium,
+            "Ca" => estimate.Calcium,
+            "Mg" => estimate.Magnesium,
+            "Cl" => estimate.Chloride,
+            "S" => estimate.Sulfate,
+            _ => estimate.Phosphate,
+        };
+
+        // Assert
+        contribution.Should().BeApproximately(expectedMicroSiemens, 1e-9);
+    }
+
+    /// <summary>
+    /// Ammonium and bicarbonate have no element of their own to pin through, so they are read from the ion
+    /// they belong to. NH₄⁺ shares potassium's mobility almost exactly, which is why they carry the same
+    /// figure.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_AmmoniumAndBicarbonate_MatchTheirReferenceValues()
+    {
+        // Arrange
+        Ppm ammonium = new PpmBuilder().AddAmmonium(14.007).AddLiters(100).Build();
+
+        // Act & Assert
+        ammonium.EstimateConductivity().Ammonium.Should().BeApproximately(73.5, 1e-9);
+
+        Ppm blank = new PpmBuilder().AddLiters(100).Build();
+        blank.EstimateConductivity(bicarbonateMeqPerLitre: 1).Bicarbonate
+            .Should().BeApproximately(44.5, 1e-9);
+    }
+
+    /// <summary>
+    /// The divalent conductivities are per mole of ion, not per equivalent — the distinction that halves or
+    /// doubles a figure depending on which convention a table uses. Calcium's 119.0 is 2 × 59.5 and sulfate's
+    /// 160.0 is 2 × 80.0, so each divalent ion must come out above every monovalent one here.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_DivalentConductivities_ArePerMoleNotPerEquivalent()
+    {
+        // Arrange — one millimole of each
+        Ppm profile = new PpmBuilder()
+            .AddCa(40.078).AddMg(24.305).AddS(32.06).AddK(39.098)
+            .AddLiters(100)
+            .Build();
+
+        // Act
+        ConductivityEstimate result = profile.EstimateConductivity();
+
+        // Assert
+        result.Calcium.Should().BeApproximately(2 * 59.5, 0.01);
+        result.Sulfate.Should().BeApproximately(2 * 80.0, 0.01);
+        result.Magnesium.Should().BeGreaterThan(result.Potassium);
+    }
+
+    // ---------------------------------------------------------------- the external anchor
+
+    /// <summary>
+    /// The certified KCl conductivity standards, which are what a meter is calibrated against and the only
+    /// point where this library can be checked against an external authority rather than against itself.
+    /// </summary>
+    [Theory]
+    [InlineData(0.001, 147.0, 0.005)]
+    [InlineData(0.01, 1412.0, 0.005)]
+    [InlineData(0.1, 12880.0, 0.05)]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_AgainstTheCertifiedKclStandards_StaysWithinItsStatedError(
+        double molarity,
+        double certifiedMicroSiemens,
+        double tolerance)
+    {
+        // Arrange
+        Ppm kcl = new PpmBuilder()
+            .AddK(molarity * 39098).AddCl(molarity * 35450)
+            .AddLiters(100)
+            .Build();
+
+        // Act
+        double estimate = kcl.EstimateConductivity().MicroSiemensPerCm;
+
+        // Assert
+        Math.Abs(estimate / certifiedMicroSiemens - 1).Should().BeLessThan(tolerance);
+    }
+}

--- a/tests/SYT.NPKTools.Tests/SolubilityTests.cs
+++ b/tests/SYT.NPKTools.Tests/SolubilityTests.cs
@@ -1,0 +1,373 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Concentrates;
+using SYT.NPKTools.Fertilizers;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Covers the solubility check on a concentrate.
+/// </summary>
+/// <remarks>
+/// A concentrate is the one place where a recipe can be arithmetically perfect and physically impossible,
+/// so these tests pin both halves of the check and, just as importantly, the third state. A salt with no
+/// published figure must be reported as unchecked rather than passed as fine — a check that quietly treats
+/// "unknown" as "safe" is worse than no check, because it reads as a verdict.
+/// </remarks>
+public class SolubilityTests
+{
+    private static Fertilizer Salt(string name, double grams, ConcentrateType tank = ConcentrateType.A) =>
+        new FertilizerBuilder()
+            .AddName(name)
+            .AddType(tank)
+            .AddK(30)
+            .AddWeight(grams)
+            .Build();
+
+    // ---------------------------------------------------------------- the single-salt check
+
+    /// <summary>
+    /// The certain half of the check: one salt, one published figure, arithmetic. Monocalcium phosphate is
+    /// the case that matters, at 18 g/L against nitrates in the hundreds — it is what actually binds first
+    /// in a real concentrate.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_SaltPastItsOwnLimit_IsFlagged()
+    {
+        // Arrange — 200 g of a salt that dissolves to 18 g/L, into 1 litre
+        Fertilizer monocalciumPhosphate = new FertilizerBuilder()
+            .AddName("Calcium Monobasic Phosphate")
+            .AddType(ConcentrateType.B)
+            .AddCaNonChelated(15.9).AddP(24.6)
+            .AddWeight(200)
+            .Build();
+        Solution solution = new([monocalciumPhosphate], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.ExceedsSolubility.Should().BeTrue();
+        plan.TankB.Components[0].SolubilityLimit.Should().Be(18);
+        plan.TankB.Components[0].ExceedsSolubility.Should().BeTrue();
+        plan.Warnings.Should().Contain(w => w.Kind == ConcentrateWarningKind.SolubilityExceeded);
+    }
+
+    /// <summary>
+    /// The same salt at a strength it can reach must not be flagged, or the check would block every
+    /// concentrate containing it.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_SaltWithinItsLimit_IsNotFlagged()
+    {
+        // Arrange — 10 g into 1 litre, against a limit of 18
+        Fertilizer monocalciumPhosphate = new FertilizerBuilder()
+            .AddName("Calcium Monobasic Phosphate")
+            .AddType(ConcentrateType.B)
+            .AddCaNonChelated(15.9).AddP(24.6)
+            .AddWeight(10)
+            .Build();
+        Solution solution = new([monocalciumPhosphate], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.ExceedsSolubility.Should().BeFalse();
+        plan.TankB.Components[0].SaturationFraction.Should().BeApproximately(10 / 18d, 1e-9);
+    }
+
+    // ---------------------------------------------------------------- the mixture screen
+
+    /// <summary>
+    /// Salts in one tank compete for the same water, so checking each against its own limit alone is too
+    /// permissive: several salts each comfortably under their own limit will still fail to dissolve
+    /// together. Adding the fractions is the screen for that, and without it a tank at 600 g/L of very
+    /// soluble nitrates passes while being impossible.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_SaltsEachUnderTheirLimitButSaturatedTogether_IsFlagged()
+    {
+        // Arrange — two salts at roughly 60% of their own limits, so neither trips the single-salt check
+        Fertilizer potassiumNitrate = new FertilizerBuilder()
+            .AddName("Potassium Nitrate").AddType(ConcentrateType.A)
+            .AddNo3(13.85).AddK(38.67).AddWeight(190).Build();          // limit 316
+        Fertilizer potassiumSulfate = new FertilizerBuilder()
+            .AddName("Potassium Sulfate (SOP)").AddType(ConcentrateType.A)
+            .AddK(44.87).AddS(18.4).AddWeight(67).Build();              // limit 111
+        Solution solution = new([potassiumNitrate, potassiumSulfate], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.TankA.Components.Should().AllSatisfy(c => c.ExceedsSolubility.Should().BeFalse());
+        plan.TankA.IsSaturated.Should().BeTrue();
+        plan.TankA.SaturationFraction.Should().BeGreaterThan(1);
+        plan.Warnings.Should().Contain(w => w.Kind == ConcentrateWarningKind.TankSaturated);
+        plan.ExceedsSolubility.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The saturation figure has to be the sum of the shares, because that is the claim being made. Pinning
+    /// the arithmetic keeps a later change from turning it into a maximum or an average, which would look
+    /// similar and behave differently.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_TankSaturation_IsTheSumOfEachSaltsShare()
+    {
+        // Arrange
+        Fertilizer potassiumNitrate = new FertilizerBuilder()
+            .AddName("Potassium Nitrate").AddType(ConcentrateType.A)
+            .AddNo3(13.85).AddK(38.67).AddWeight(31.6).Build();         // 10% of 316
+        Fertilizer potassiumSulfate = new FertilizerBuilder()
+            .AddName("Potassium Sulfate (SOP)").AddType(ConcentrateType.A)
+            .AddK(44.87).AddS(18.4).AddWeight(22.2).Build();            // 20% of 111
+        Solution solution = new([potassiumNitrate, potassiumSulfate], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.TankA.SaturationFraction.Should().BeApproximately(0.30, 1e-6);
+        plan.TankA.IsSaturated.Should().BeFalse();
+    }
+
+    // ---------------------------------------------------------------- the ceiling
+
+    /// <summary>
+    /// When a concentrate is too strong, the actionable answer is how strong it may be. A plan at more than
+    /// the ceiling must flag; the same recipe just inside it must not — which is what makes the number
+    /// usable rather than decorative.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_MaxDilutionRatio_IsTheStrengthAtWhichTheCheckStopsFiring()
+    {
+        // Arrange
+        Fertilizer potassiumNitrate = new FertilizerBuilder()
+            .AddName("Potassium Nitrate").AddType(ConcentrateType.A)
+            .AddNo3(13.85).AddK(38.67).AddWeight(100).Build();
+        Solution solution = new([potassiumNitrate], waterLiters: 100);
+
+        // Act
+        double ceiling = solution.AsConcentrate(concentrateLiters: 1).MaxDilutionRatio!.Value;
+
+        // Assert — 100 g at 316 g/L fits in 0.316 L, so the ceiling is 100 / 0.316
+        ceiling.Should().BeApproximately(316, 0.5);
+
+        // just inside the ceiling: fine; just outside: flagged
+        solution.AsConcentrate(100 / (ceiling * 0.98)).ExceedsSolubility.Should().BeFalse();
+        solution.AsConcentrate(100 / (ceiling * 1.02)).ExceedsSolubility.Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------- unknown is not safe
+
+    /// <summary>
+    /// The third state, and the one a naive check gets wrong. A salt with no published figure must come
+    /// back as unchecked, not as fine — and no ceiling can be computed either, because the missing salt
+    /// could be the one that binds.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_SaltWithNoKnownLimit_IsReportedAsUncheckedRatherThanSafe()
+    {
+        // Arrange — a made-up name, at a strength nothing could dissolve at
+        Solution solution = new([Salt("My Own Mystery Salt", grams: 5000)], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.UnknownSolubility.Should().BeEquivalentTo(["My Own Mystery Salt"]);
+        plan.TankA.Components[0].SolubilityLimit.Should().BeNull();
+        plan.TankA.Components[0].SaturationFraction.Should().BeNull();
+        plan.TankA.SaturationFraction.Should().BeNull();
+        plan.MaxDilutionRatio.Should().BeNull();
+        plan.ExceedsSolubility.Should().BeFalse("nothing was checked, so nothing can be claimed");
+    }
+
+    /// <summary>
+    /// A tank holding one known salt and one unknown one reports no saturation figure at all, rather than a
+    /// partial sum. A sum missing a term reads as a verdict on the tank while being one.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_TankWithOneUnknownSalt_ReportsNoSaturationRatherThanAPartialSum()
+    {
+        // Arrange
+        Solution solution = new(
+            [Salt("Potassium Nitrate", grams: 100), Salt("My Own Mystery Salt", grams: 100)],
+            waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.TankA.Components.Should().HaveCount(2);
+        plan.TankA.SaturationFraction.Should().BeNull();
+        plan.TankA.IsSaturated.Should().BeFalse();
+        plan.UnknownSolubility.Should().BeEquivalentTo(["My Own Mystery Salt"]);
+    }
+
+    /// <summary>
+    /// A caller's own salt becomes checkable the moment they supply a figure from the bag, which is the
+    /// intended way out of the unknown state.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_CustomSaltWithASuppliedFigure_IsCheckedLikeAnyOther()
+    {
+        // Arrange
+        SolubilityTable table = SolubilityTable.Default.With("My Own Mystery Salt", 50);
+        Solution solution = new([Salt("My Own Mystery Salt", grams: 100)], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1, table);
+
+        // Assert — 100 g into 1 L is 100 g/L against a supplied 50
+        plan.UnknownSolubility.Should().BeEmpty();
+        plan.ExceedsSolubility.Should().BeTrue();
+        plan.MaxDilutionRatio.Should().BeApproximately(50, 1e-6);
+    }
+
+    /// <summary>
+    /// A miscible substance has no limit to exceed, so it must never be flagged and must never cap the
+    /// ceiling. Phosphoric acid is the case in the catalogue.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_MiscibleSubstance_NeitherFlagsNorCapsTheCeiling()
+    {
+        // Arrange
+        Fertilizer acid = new FertilizerBuilder()
+            .AddName("Phosphoric Acid").AddType(ConcentrateType.B)
+            .AddP(31.6).AddWeight(500).Build();
+        Solution solution = new([acid], waterLiters: 100);
+
+        // Act
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 1);
+
+        // Assert
+        plan.TankB.Components[0].SolubilityLimit.Should().Be(double.PositiveInfinity);
+        plan.ExceedsSolubility.Should().BeFalse();
+        plan.UnknownSolubility.Should().BeEmpty();
+        plan.MaxDilutionRatio.Should().BeNull("nothing in the tank has a finite limit to bind against");
+    }
+
+    // ---------------------------------------------------------------- the table itself
+
+    /// <summary>
+    /// Every name in the table has to match a catalogue entry exactly, because a mismatch fails silently:
+    /// the salt simply reports as unchecked and the check appears to work. This is the one test that would
+    /// have caught the five misspelled micro-salt names in the first version of the table.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Default_EveryNameInTheTable_MatchesACatalogueSalt()
+    {
+        // Arrange
+        IFertilizerBundleRepository catalogue = NpkTools.CreateBundleRepository();
+        HashSet<string> catalogueNames =
+        [
+            .. catalogue.Macro().SelectMany(b => b)
+                .Concat(catalogue.Micro().SelectMany(b => b))
+                .Select(f => f.Name.Value)
+        ];
+
+        // Act — every catalogue salt the table claims to know about must actually resolve
+        int resolved = catalogueNames.Count(name => SolubilityTable.Default.Limit(name) is not null);
+
+        // Assert
+        resolved.Should().Be(SolubilityTable.Default.Count,
+            "a name in the table that matches no catalogue salt is a silent no-op");
+    }
+
+    /// <summary>
+    /// The salts a concentrate is most likely to run into are the barely soluble ones, so their figures are
+    /// pinned by value. A typo turning 18 into 180 would let an impossible tank through unnoticed.
+    /// </summary>
+    [Theory]
+    [InlineData("Calcium Monobasic Phosphate", 18)]
+    [InlineData("Boric Acid", 49)]
+    [InlineData("Sodium Borate Decahydrate", 51)]
+    [InlineData("Potassium Sulfate (SOP)", 111)]
+    [InlineData("Potassium Dihydrogen Phosphate (MKP)", 226)]
+    [Trait("Category", "Unit")]
+    public void Default_TheLowSolubilityFigures_ArePinned(string name, double expected)
+    {
+        // Act & Assert
+        SolubilityTable.Default.Limit(name).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Names are matched case-insensitively, because a caller retyping a salt name will not match its
+    /// capitalisation and a silent miss is the failure mode here.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Limit_MatchesNamesWithoutRegardToCase()
+    {
+        // Act & Assert
+        SolubilityTable.Default.Limit("potassium nitrate").Should().Be(316);
+        SolubilityTable.Default.Limit("POTASSIUM NITRATE").Should().Be(316);
+        SolubilityTable.Default.Limit("not a salt").Should().BeNull();
+    }
+
+    /// <summary>
+    /// <c>With</c> must not mutate the table it was called on; <see cref="SolubilityTable.Default"/> is a
+    /// shared static and a caller adding their own salt must not change it for everyone else.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void With_LeavesTheOriginalTableUntouched()
+    {
+        // Arrange
+        int before = SolubilityTable.Default.Count;
+
+        // Act
+        SolubilityTable extended = SolubilityTable.Default.With("Something Of My Own", 42);
+
+        // Assert
+        extended.Limit("Something Of My Own").Should().Be(42);
+        SolubilityTable.Default.Limit("Something Of My Own").Should().BeNull();
+        SolubilityTable.Default.Count.Should().Be(before);
+    }
+
+    /// <summary>
+    /// A solubility of zero or less is not a quantity that can dissolve, and NaN would make every
+    /// comparison false — silently disabling the check for that salt.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(double.NaN)]
+    [Trait("Category", "Unit")]
+    public void Constructor_ImpossibleSolubility_Throws(double limit)
+    {
+        // Act
+        Action act = () => new SolubilityTable(new Dictionary<string, double> { ["Salt"] = limit });
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// Guards the remaining entry points.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Table_NullOrBlankArguments_Throw()
+    {
+        // Act & Assert
+        ((Action)(() => new SolubilityTable(null!))).Should().Throw<ArgumentNullException>();
+        ((Action)(() => SolubilityTable.Default.With(null!, 10))).Should().Throw<ArgumentException>();
+        ((Action)(() => SolubilityTable.Default.With("  ", 10))).Should().Throw<ArgumentException>();
+        ((Action)(() => SolubilityTable.Default.With("Salt", -1))).Should().Throw<ArgumentOutOfRangeException>();
+        SolubilityTable.Empty.Count.Should().Be(0);
+    }
+}

--- a/tests/SYT.NPKTools.Tests/SolubilityTests.cs
+++ b/tests/SYT.NPKTools.Tests/SolubilityTests.cs
@@ -288,20 +288,76 @@ public class SolubilityTests
     }
 
     /// <summary>
-    /// The salts a concentrate is most likely to run into are the barely soluble ones, so their figures are
-    /// pinned by value. A typo turning 18 into 180 would let an impossible tank through unnoticed.
+    /// Every figure in the table is pinned, not just the low ones.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An earlier version of this test pinned only the five lowest values, on the reasoning that those are
+    /// the ones a concentrate runs into. That reasoning was wrong in a way worth recording: three entries
+    /// turned out to be incorrect on review, and none of the three was among the five, so the suite passed
+    /// while the table was wrong. Ammonium nitrate carried its 10 °C figure rather than its 20 °C one;
+    /// magnesium nitrate hexahydrate and zinc sulfate monohydrate carried figures for the anhydrous salt
+    /// under the hydrate's name, overstating both — the direction that passes a tank which cannot dissolve.
+    /// </para>
+    /// <para>
+    /// So the whole table is pinned. Each expected value is ten times the published "g per 100 mL" entry for
+    /// the named hydrate, which is the basis the table documents, and a change to any of them now has to be
+    /// deliberate.
+    /// </para>
+    /// </remarks>
     [Theory]
+    // Macro salts.
     [InlineData("Calcium Monobasic Phosphate", 18)]
-    [InlineData("Boric Acid", 49)]
-    [InlineData("Sodium Borate Decahydrate", 51)]
     [InlineData("Potassium Sulfate (SOP)", 111)]
     [InlineData("Potassium Dihydrogen Phosphate (MKP)", 226)]
+    [InlineData("Potassium Chloride", 344)]
+    [InlineData("Ammonium Chloride", 372)]
+    [InlineData("Monoammonium Phosphate", 383)]
+    [InlineData("Magnesium Nitrate Hexahydrate (MAG)", 420)]
+    [InlineData("Potassium Nitrate", 316)]
+    [InlineData("Magnesium Sulfate Heptahydrate (MGS)", 710)]
+    [InlineData("Ammonium Sulfate", 754)]
+    [InlineData("Urea", 1080)]
+    [InlineData("Calcium Nitrate Tetrahydrate", 1290)]
+    [InlineData("Potassium Dibasic Phosphate", 1490)]
+    [InlineData("Ammonium Nitrate", 1920)]
+    // Micro salts.
+    [InlineData("Boric Acid", 49)]
+    [InlineData("Sodium Borate Decahydrate", 51)]
+    [InlineData("Iron(II) Sulfate Heptahydrate", 256)]
+    [InlineData("Copper Sulfate Pentahydrate", 320)]
+    [InlineData("Zinc Sulfate Monohydrate", 350)]
+    [InlineData("Sodium Molybdate Dihydrate", 840)]
     [Trait("Category", "Unit")]
-    public void Default_TheLowSolubilityFigures_ArePinned(string name, double expected)
+    public void Default_EverySolubilityFigure_IsPinned(string name, double expected)
     {
         // Act & Assert
         SolubilityTable.Default.Limit(name).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Phosphoric acid is miscible, so it has a limit that nothing can exceed rather than no limit at all —
+    /// the difference between "always fine" and "unchecked".
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Default_PhosphoricAcid_IsMiscibleRatherThanUnknown()
+    {
+        // Act & Assert
+        SolubilityTable.Default.Limit("Phosphoric Acid").Should().Be(double.PositiveInfinity);
+    }
+
+    /// <summary>
+    /// The count is pinned alongside the values so that adding an entry without pinning it fails here. Without
+    /// this, a new salt could be added and silently go unasserted, which is how the three wrong figures
+    /// survived.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Default_TableSize_MatchesThePinnedEntries()
+    {
+        // Act & Assert — 20 figures above plus phosphoric acid
+        SolubilityTable.Default.Count.Should().Be(21);
     }
 
     /// <summary>

--- a/tests/SYT.NPKTools.Tests/SolubilityTests.cs
+++ b/tests/SYT.NPKTools.Tests/SolubilityTests.cs
@@ -165,6 +165,76 @@ public class SolubilityTests
         solution.AsConcentrate(100 / (ceiling * 1.02)).ExceedsSolubility.Should().BeTrue();
     }
 
+    /// <summary>
+    /// A salt with no known limit must not cancel the limits that <em>are</em> known. This was a defect: a tank
+    /// holding one custom salt beside an over-limit MKP reported no constraint of its own, so the ceiling came
+    /// from the other tank entirely and came out 28× too high — the grower is told to go to 1:1290 for a tank
+    /// that stops dissolving near 1:45.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_UnknownSaltBesideAKnownOne_DoesNotCancelTheKnownLimit()
+    {
+        // Arrange — tank A comfortable, tank B far over on MKP, plus a custom salt with no figure
+        Fertilizer calciumNitrate = new FertilizerBuilder()
+            .AddName("Calcium Nitrate Tetrahydrate").AddType(ConcentrateType.A)
+            .AddNo3(11.86).AddCaNonChelated(16.97).AddWeight(100).Build();
+        Fertilizer mkp = new FertilizerBuilder()
+            .AddName("Potassium Dihydrogen Phosphate (MKP)").AddType(ConcentrateType.B)
+            .AddP(22.76).AddK(28.73).AddWeight(500).Build();
+        Fertilizer custom = Salt("My Custom Sulfate", grams: 10, ConcentrateType.B);
+
+        Solution withUnknown = new([calciumNitrate, mkp, custom], waterLiters: 100);
+        Solution knownOnly = new([calciumNitrate, mkp], waterLiters: 100);
+
+        // Act
+        double? ceilingWithUnknown = withUnknown.AsConcentrate(1).MaxDilutionRatio;
+        double? ceilingKnownOnly = knownOnly.AsConcentrate(1).MaxDilutionRatio;
+
+        // Assert — the unknown salt loosens nothing; MKP still sets the ceiling
+        ceilingWithUnknown.Should().BeApproximately(ceilingKnownOnly!.Value, 1e-9);
+        ceilingWithUnknown.Should().BeApproximately(45.2, 0.1);
+    }
+
+    /// <summary>
+    /// The invariant behind the ceiling: at the ratio it reports, no salt with a known limit may already be
+    /// over that limit. Otherwise the number is not a ceiling but an invitation.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_AtTheReportedCeiling_NoKnownLimitIsAlreadyExceeded()
+    {
+        // Arrange
+        Fertilizer mkp = new FertilizerBuilder()
+            .AddName("Potassium Dihydrogen Phosphate (MKP)").AddType(ConcentrateType.B)
+            .AddP(22.76).AddK(28.73).AddWeight(500).Build();
+        Solution solution = new([mkp, Salt("My Custom Sulfate", grams: 10, ConcentrateType.B)], waterLiters: 100);
+
+        // Act — a hair inside the ceiling means a slightly larger tank, so a weaker one
+        double ceiling = solution.AsConcentrate(1).MaxDilutionRatio!.Value;
+        ConcentratePlan justInside = solution.AsConcentrate(100 / ceiling * 1.01);
+
+        // Assert
+        justInside.TankB.Components
+            .Where(c => c.SolubilityLimit is not null)
+            .Should().AllSatisfy(c => c.ExceedsSolubility.Should().BeFalse());
+    }
+
+    /// <summary>
+    /// A tank whose only salt has no figure genuinely cannot be bounded, and null is the right answer there —
+    /// the distinction being that nothing was discarded, there was nothing to discard.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_NothingWithAKnownLimitAnywhere_HasNoCeiling()
+    {
+        // Arrange
+        Solution solution = new([Salt("My Own Mystery Salt", grams: 100)], waterLiters: 100);
+
+        // Act & Assert
+        solution.AsConcentrate(1).MaxDilutionRatio.Should().BeNull();
+    }
+
     // ---------------------------------------------------------------- unknown is not safe
 
     /// <summary>

--- a/tests/SYT.NPKTools.Tests/TankProfileTests.cs
+++ b/tests/SYT.NPKTools.Tests/TankProfileTests.cs
@@ -1,0 +1,271 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Nutrients;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Covers composing a mix with its source water, and the bicarbonate term in the conductivity estimate.
+/// </summary>
+/// <remarks>
+/// Both of these close the same gap from opposite ends. Every analysis in the library describes the profile
+/// it is handed, so handing it a mix's own ppm silently answers a question nobody asked — what the salts
+/// would read in pure water. For a hard supply that is 22% below what the meter in the reservoir shows, and
+/// two-thirds of the shortfall is the water's nutrients while the rest is its bicarbonate.
+/// </remarks>
+public class TankProfileTests
+{
+    private static WaterProfile TapWater() => new WaterProfileBuilder()
+        .AddCa(45).AddMg(12).AddS(18).AddNa(20).AddCl(25)
+        .Build();
+
+    private static Ppm SaltsOnly() => new PpmBuilder()
+        .AddNitrate(143).AddAmmonium(7).AddP(50).AddK(210).AddCa(115).AddMg(38).AddS(47)
+        .AddLiters(100)
+        .Build();
+
+    // ---------------------------------------------------------------- composition
+
+    /// <summary>
+    /// The nitrogen forms have to be added form by form. Collapsing them to a total and re-splitting it is
+    /// the mistake this method exists to prevent — it drops the ammonium, which moves the charge balance, the
+    /// NO₃:NH₄ ratio and the conductivity all at once.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Plus_KeepsAllThreeNitrogenFormsSeparate()
+    {
+        // Arrange
+        WaterProfile water = new WaterProfileBuilder().AddNitrate(6).AddAmmonium(2).AddAmine(1).Build();
+
+        // Act
+        Ppm tank = SaltsOnly().Plus(water);
+
+        // Assert
+        tank.Nitrogen.Nitrate.Should().Be(149);
+        tank.Nitrogen.Ammonium.Should().Be(9);
+        tank.Nitrogen.Amine.Should().Be(1);
+        tank.Nitrogen.Value.Should().Be(159);
+    }
+
+    /// <summary>
+    /// Every element must be carried, or an omitted one reads as absent from the reservoir when it is present.
+    /// Sodium and chloride matter most here: they come almost entirely from the water and appear in no target.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Plus_AddsEveryElementFromBothSides()
+    {
+        // Act
+        Ppm tank = SaltsOnly().Plus(TapWater());
+
+        // Assert
+        tank.Calcium.Value.Should().Be(115 + 45);
+        tank.Magnesium.Value.Should().Be(38 + 12);
+        tank.Sulfur.Value.Should().Be(47 + 18);
+        tank.Sodium.Value.Should().Be(20);
+        tank.Chlorine.Value.Should().Be(25);
+        tank.Potassium.Value.Should().Be(210);
+    }
+
+    /// <summary>
+    /// The reservoir volume belongs to the mix; the water analysis is a concentration and carries none. If the
+    /// volume moved, the recipe would no longer describe the same batch.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Plus_KeepsTheMixesOwnWaterVolume()
+    {
+        // Act
+        Ppm tank = SaltsOnly().Plus(TapWater());
+
+        // Assert
+        tank.Liters.Value.Should().Be(100);
+    }
+
+    /// <summary>
+    /// Reverse osmosis water changes nothing, which is the regression guard for anyone who does not have a
+    /// water analysis to supply.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Plus_PureWater_ChangesNothing()
+    {
+        // Arrange
+        Ppm salts = SaltsOnly();
+
+        // Act
+        Ppm tank = salts.Plus(WaterProfile.Pure);
+
+        // Assert
+        tank.Calcium.Value.Should().Be(salts.Calcium.Value);
+        tank.EstimateConductivity().MicroSiemensPerCm
+            .Should().BeApproximately(salts.EstimateConductivity().MicroSiemensPerCm, 1e-9);
+    }
+
+    /// <summary>
+    /// The composed profile lands on the original target, which is the whole point of deducting the water
+    /// beforehand — and the check that the deduction and the composition agree with each other.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Plus_RecomposesTheTargetTheWaterWasDeductedFrom()
+    {
+        // Arrange
+        PpmTarget original = new PpmTargetBuilder()
+            .AddN(150).AddP(50).AddK(210).AddCa(160).AddMg(50).AddS(65).AddLiters(100)
+            .Build();
+        WaterProfile water = TapWater();
+        PpmTarget adjusted = original.AdjustFor(water).Target;
+
+        // Act — a mix meeting the adjusted target, put back into the water it was adjusted for
+        Ppm salts = new PpmBuilder()
+            .AddNitrate(adjusted.N.Value).AddP(adjusted.P.Value).AddK(adjusted.K.Value)
+            .AddCa(adjusted.Ca.Value).AddMg(adjusted.Mg.Value).AddS(adjusted.S.Value)
+            .AddLiters(100)
+            .Build();
+        Ppm tank = salts.Plus(water);
+
+        // Assert
+        tank.Calcium.Value.Should().BeApproximately(original.Ca.Value, 1e-9);
+        tank.Magnesium.Value.Should().BeApproximately(original.Mg.Value, 1e-9);
+        tank.Sulfur.Value.Should().BeApproximately(original.S.Value, 1e-9);
+    }
+
+    // ---------------------------------------------------------------- EC of the reservoir
+
+    /// <summary>
+    /// The number that makes the feature worth having: on a hard supply the reservoir reads well above what
+    /// the salts alone would, so a caller measuring against a salts-only figure would think their feed was
+    /// weak and push it further.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_ReservoirVersusSaltsAlone_DiffersByAFifth()
+    {
+        // Arrange
+        WaterProfile water = TapWater();
+        Ppm salts = SaltsOnly();
+
+        // Act
+        double saltsOnly = salts.EstimateConductivity().MilliSiemensPerCm;
+        double reservoir = salts.Plus(water).EstimateConductivity(water.EstimatedAlkalinity())
+            .MilliSiemensPerCm;
+
+        // Assert
+        (reservoir / saltsOnly).Should().BeInRange(1.15, 1.30);
+    }
+
+    // ---------------------------------------------------------------- bicarbonate
+
+    /// <summary>
+    /// Bicarbonate carries most of the negative charge in tap water. Leaving it out understates a moderately
+    /// hard supply by around a quarter, which is the figure the documentation quotes.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_WaterWithAndWithoutBicarbonate_DiffersByAboutAQuarter()
+    {
+        // Arrange
+        WaterProfile water = TapWater();
+
+        // Act
+        double without = water.AsPpm().EstimateConductivity().MicroSiemensPerCm;
+        double with = water.EstimateConductivity().MicroSiemensPerCm;
+
+        // Assert
+        without.Should().BeApproximately(358, 5);
+        with.Should().BeApproximately(454, 5);
+        (with / without - 1).Should().BeInRange(0.20, 0.32);
+    }
+
+    /// <summary>
+    /// The overload on <see cref="WaterProfile"/> is the same call with the alkalinity filled in, and it must
+    /// stay that way — inferring bicarbonate is defensible for a water analysis and wrong for a recipe, where
+    /// the same charge gap is the salts' acid-base character.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_OnWaterProfile_FillsInItsOwnAlkalinity()
+    {
+        // Arrange
+        WaterProfile water = TapWater();
+
+        // Act
+        ConductivityEstimate implicitly = water.EstimateConductivity();
+        ConductivityEstimate explicitly = water.AsPpm()
+            .EstimateConductivity(water.EstimatedAlkalinity());
+
+        // Assert
+        implicitly.MicroSiemensPerCm.Should().BeApproximately(explicitly.MicroSiemensPerCm, 1e-9);
+        implicitly.Bicarbonate.Should().BeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// Bicarbonate is monovalent, so its share is its meq/L times the ion's molar conductivity, and it must
+    /// raise ionic strength as well — the correction has to know about the ion that was added.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_Bicarbonate_ContributesAndRaisesIonicStrength()
+    {
+        // Arrange
+        Ppm profile = new PpmBuilder().AddK(39.098).AddLiters(100).Build();
+
+        // Act
+        ConductivityEstimate without = profile.EstimateConductivity();
+        ConductivityEstimate with = profile.EstimateConductivity(bicarbonateMeqPerLitre: 1);
+
+        // Assert
+        with.Bicarbonate.Should().BeApproximately(44.5, 0.01);
+        with.IonicStrength.Should().BeApproximately(without.IonicStrength + 0.0005, 1e-9);
+        with.IdealMicroSiemensPerCm.Should()
+            .BeApproximately(without.IdealMicroSiemensPerCm + 44.5, 0.01);
+    }
+
+    /// <summary>
+    /// Reverse osmosis water has no alkalinity, so no bicarbonate term appears.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_PureWater_HasNoBicarbonate()
+    {
+        // Act
+        ConductivityEstimate result = WaterProfile.Pure.EstimateConductivity();
+
+        // Assert
+        result.Bicarbonate.Should().Be(0);
+        result.MicroSiemensPerCm.Should().Be(0);
+    }
+
+    // ---------------------------------------------------------------- guards
+
+    /// <summary>
+    /// Negative bicarbonate is not a quantity, and left unchecked it would quietly reduce a conductivity
+    /// estimate.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_NegativeBicarbonate_Throws()
+    {
+        // Act
+        Action act = () => SaltsOnly().EstimateConductivity(-1);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// Guards both sides of the composition.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Plus_NullArguments_Throw()
+    {
+        // Act & Assert
+        ((Action)(() => PpmExtensions.Plus(null!, TapWater()))).Should().Throw<ArgumentNullException>();
+        ((Action)(() => SaltsOnly().Plus(null!))).Should().Throw<ArgumentNullException>();
+        ((Action)(() => WaterProfileExtensions.EstimateConductivity(null!)))
+            .Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/SYT.NPKTools.Tests/WaterProfileAnalysisTests.cs
+++ b/tests/SYT.NPKTools.Tests/WaterProfileAnalysisTests.cs
@@ -1,0 +1,159 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Nutrients;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Covers reading a source-water analysis with the solution analyses.
+/// </summary>
+/// <remarks>
+/// The alkalinity estimate is the interesting one and the reasoning is worth restating, because it looks
+/// like a bug at first glance. A finished recipe's cations equal its anions; a water analysis's do not, and
+/// that is not a mistake in the analysis. Bicarbonate is what balances real water and it is not a plant
+/// nutrient, so it has nowhere to be entered — leaving the gap as a measurement of it.
+/// </remarks>
+public class WaterProfileAnalysisTests
+{
+    private static WaterProfile ModeratelyHardTapWater() => new WaterProfileBuilder()
+        .AddCa(45).AddMg(12).AddS(18).AddNa(20).AddCl(25)
+        .Build();
+
+    /// <summary>
+    /// The worked example the documentation quotes, pinned so the two cannot drift apart. 2.27 meq/L is about
+    /// 139 ppm of bicarbonate or 114 as calcium carbonate — an ordinary municipal supply.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimatedAlkalinity_ModeratelyHardWater_IsTheCationSurplus()
+    {
+        // Arrange
+        WaterProfile tap = ModeratelyHardTapWater();
+
+        // Act
+        double alkalinity = tap.EstimatedAlkalinity();
+        IonBalance balance = tap.AsPpm().IonBalance();
+
+        // Assert
+        alkalinity.Should().BeApproximately(2.27, 0.02);
+        alkalinity.Should().BeApproximately(-balance.AcidEquivalents, 1e-9);
+        (alkalinity * 61).Should().BeApproximately(139, 2, "ppm of HCO3-");
+        (alkalinity * 50).Should().BeApproximately(114, 2, "ppm as CaCO3");
+    }
+
+    /// <summary>
+    /// Reverse osmosis water has nothing in it, so it must report no alkalinity and no conductivity rather
+    /// than a small artefact of the arithmetic.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimatedAlkalinity_PureWater_IsZero()
+    {
+        // Act & Assert
+        WaterProfile.Pure.EstimatedAlkalinity().Should().Be(0);
+        WaterProfile.Pure.AsPpm().EstimateConductivity().MicroSiemensPerCm.Should().Be(0);
+    }
+
+    /// <summary>
+    /// An analysis with more anions than cations cannot have negative alkalinity — there is no such thing —
+    /// so the estimate clamps at zero rather than reporting a number that reads as acidity.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimatedAlkalinity_AnionHeavyAnalysis_IsZeroRatherThanNegative()
+    {
+        // Arrange — a sulfate-dominated or acidified supply
+        WaterProfile water = new WaterProfileBuilder().AddCa(10).AddS(60).AddCl(40).Build();
+
+        // Act & Assert
+        water.EstimatedAlkalinity().Should().Be(0);
+    }
+
+    /// <summary>
+    /// A water analysis is a concentration, so the nominal volume must not change anything read from it. If
+    /// it did, the parameter would be a trap.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsPpm_NominalVolume_DoesNotAffectAnyReading()
+    {
+        // Arrange
+        WaterProfile tap = ModeratelyHardTapWater();
+
+        // Act
+        ConductivityEstimate atOneLiter = tap.AsPpm(1).EstimateConductivity();
+        ConductivityEstimate atAThousand = tap.AsPpm(1000).EstimateConductivity();
+
+        // Assert
+        atAThousand.MicroSiemensPerCm.Should().BeApproximately(atOneLiter.MicroSiemensPerCm, 1e-9);
+    }
+
+    /// <summary>
+    /// The conversion has to carry every element across, including the nitrogen forms separately — an
+    /// analysis reporting nitrate must not have it silently become ammonium, which would move both the
+    /// charge balance and the ratios.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsPpm_CarriesEveryElementAcross()
+    {
+        // Arrange
+        WaterProfile water = new WaterProfileBuilder()
+            .AddNitrate(6).AddAmmonium(2).AddP(1).AddK(3).AddCa(45).AddMg(12).AddS(18)
+            .AddFe(0.1).AddCu(0.02).AddMn(0.05).AddZn(0.03).AddB(0.04).AddMo(0.01)
+            .AddCl(25).AddSi(8).AddSe(0.005).AddNa(20)
+            .Build();
+
+        // Act
+        Ppm ppm = water.AsPpm();
+
+        // Assert
+        ppm.Nitrogen.Nitrate.Should().Be(6);
+        ppm.Nitrogen.Ammonium.Should().Be(2);
+        ppm.Phosphorus.Value.Should().Be(1);
+        ppm.Potassium.Value.Should().Be(3);
+        ppm.Calcium.Value.Should().Be(45);
+        ppm.Magnesium.Value.Should().Be(12);
+        ppm.Sulfur.Value.Should().Be(18);
+        ppm.Iron.Value.Should().Be(0.1);
+        ppm.Copper.Value.Should().Be(0.02);
+        ppm.Manganese.Value.Should().Be(0.05);
+        ppm.Zinc.Value.Should().Be(0.03);
+        ppm.Boron.Value.Should().Be(0.04);
+        ppm.Molybdenum.Value.Should().Be(0.01);
+        ppm.Chlorine.Value.Should().Be(25);
+        ppm.Silicon.Value.Should().Be(8);
+        ppm.Selenium.Value.Should().Be(0.005);
+        ppm.Sodium.Value.Should().Be(20);
+    }
+
+    /// <summary>
+    /// The water's own EC is the quickest check that an analysis was entered correctly, so it has to land in
+    /// the range a meter would show for water of that hardness — a few hundred µS/cm.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EstimateConductivity_ModeratelyHardWater_ReadsInTheRangeAMeterWould()
+    {
+        // Act
+        double microSiemens = ModeratelyHardTapWater().AsPpm().EstimateConductivity().MicroSiemensPerCm;
+
+        // Assert
+        microSiemens.Should().BeInRange(250, 500);
+    }
+
+    /// <summary>
+    /// Guards both entry points.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Extensions_InvalidArguments_Throw()
+    {
+        // Act & Assert
+        ((Action)(() => WaterProfileExtensions.AsPpm(null!))).Should().Throw<ArgumentNullException>();
+        ((Action)(() => WaterProfileExtensions.EstimatedAlkalinity(null!)))
+            .Should().Throw<ArgumentNullException>();
+        ((Action)(() => WaterProfile.Pure.AsPpm(0))).Should().Throw<ArgumentOutOfRangeException>();
+        ((Action)(() => WaterProfile.Pure.AsPpm(-1))).Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/SYT.NPKTools.Tests/WaterProfileTests.cs
+++ b/tests/SYT.NPKTools.Tests/WaterProfileTests.cs
@@ -1,0 +1,290 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Nutrients;
+using Xunit;
+
+namespace SYT.NPKTools.Tests;
+
+/// <summary>
+/// Covers deducting the source water's own nutrients from a target.
+/// </summary>
+/// <remarks>
+/// Skipping this deduction is the most common way to produce a mix that is right on paper and wrong in
+/// the tank, so the arithmetic is pinned in both directions: that a blank profile changes nothing, and
+/// that an oversupplied element is reported rather than silently truncated.
+/// </remarks>
+public class WaterProfileTests
+{
+    private const double Precision = 1e-9;
+
+    private static PpmTarget Target() => new PpmTargetBuilder()
+        .AddN(150).AddP(50).AddK(200).AddCa(100).AddMg(50).AddS(60).AddLiters(100)
+        .Build();
+
+    // ---------------------------------------------------------------- no water
+
+    /// <summary>
+    /// Reverse osmosis and distilled water must leave the target exactly as it was. This is the
+    /// regression guard for every existing caller: adding the feature must not move any number for
+    /// someone who does not use it.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_PureWater_LeavesTheTargetUnchanged()
+    {
+        // Arrange
+        PpmTarget target = Target();
+
+        // Act
+        WaterAdjustedTarget result = target.AdjustFor(WaterProfile.Pure);
+
+        // Assert
+        result.Target.N.Value.Should().Be(target.N.Value);
+        result.Target.P.Value.Should().Be(target.P.Value);
+        result.Target.K.Value.Should().Be(target.K.Value);
+        result.Target.Ca.Value.Should().Be(target.Ca.Value);
+        result.Target.Mg.Value.Should().Be(target.Mg.Value);
+        result.Target.S.Value.Should().Be(target.S.Value);
+        result.HasExcesses.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_AnyWater_CarriesTheWaterVolumeThrough()
+    {
+        // A water analysis is a concentration and says nothing about volume, so the target's own
+        // volume must survive untouched.
+        WaterProfile water = new WaterProfileBuilder().AddCa(30).Build();
+
+        WaterAdjustedTarget result = Target().AdjustFor(water);
+
+        result.Target.Liters.Value.Should().Be(100);
+    }
+
+    // ---------------------------------------------------------------- ordinary deduction
+
+    /// <summary>
+    /// A typical municipal analysis: hard-ish water carrying calcium, magnesium, sulfur and sodium.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_TapWater_DeductsEachElement()
+    {
+        // Arrange
+        WaterProfile water = new WaterProfileBuilder()
+            .AddCa(40)
+            .AddMg(12)
+            .AddS(15)
+            .AddNa(20)
+            .AddNitrate(5)
+            .Build();
+
+        // Act
+        WaterAdjustedTarget result = Target().AdjustFor(water);
+
+        // Assert
+        result.Target.Ca.Value.Should().BeApproximately(60, Precision);
+        result.Target.Mg.Value.Should().BeApproximately(38, Precision);
+        result.Target.S.Value.Should().BeApproximately(45, Precision);
+        result.Target.N.Value.Should().BeApproximately(145, Precision);
+        result.HasExcesses.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_UntouchedElements_AreLeftAlone()
+    {
+        // Arrange
+        WaterProfile water = new WaterProfileBuilder().AddCa(40).Build();
+
+        // Act
+        WaterAdjustedTarget result = Target().AdjustFor(water);
+
+        // Assert
+        result.Target.P.Value.Should().Be(50);
+        result.Target.K.Value.Should().Be(200);
+    }
+
+    /// <summary>
+    /// Nitrogen is deducted as a total, because a target names one nitrogen figure while an analysis may
+    /// report it split by form.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_NitrogenInSeveralForms_DeductsTheirSum()
+    {
+        // Arrange
+        WaterProfile water = new WaterProfileBuilder()
+            .AddNitrate(8)
+            .AddAmmonium(2)
+            .Build();
+
+        // Act
+        WaterAdjustedTarget result = Target().AdjustFor(water);
+
+        // Assert
+        result.Target.N.Value.Should().BeApproximately(140, Precision);
+    }
+
+    /// <summary>
+    /// Water exactly meeting a target leaves nothing for the fertilizers, and that is not an excess.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_WaterExactlyMeetingATarget_LeavesZeroAndReportsNoExcess()
+    {
+        // Arrange
+        WaterProfile water = new WaterProfileBuilder().AddCa(100).Build();
+
+        // Act
+        WaterAdjustedTarget result = Target().AdjustFor(water);
+
+        // Assert
+        result.Target.Ca.Value.Should().Be(0);
+        result.HasExcesses.Should().BeFalse();
+    }
+
+    // ---------------------------------------------------------------- excess
+
+    /// <summary>
+    /// Hard water against a low calcium target: fertilizer only adds, so this target cannot be reached
+    /// by mixing. It must be reported rather than quietly clamped, because the caller's only remedies
+    /// are outside the calculation — raise the target, or dilute the water.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_WaterOversupplyingAnElement_ClampsToZeroAndReportsIt()
+    {
+        // Arrange
+        WaterProfile water = new WaterProfileBuilder().AddCa(140).Build();
+
+        // Act
+        WaterAdjustedTarget result = Target().AdjustFor(water);
+
+        // Assert
+        result.Target.Ca.Value.Should().Be(0);
+        result.HasExcesses.Should().BeTrue();
+
+        NutrientExcess excess = result.Excesses.Should().ContainSingle().Subject;
+        excess.Element.Should().Be("Ca");
+        excess.InWater.Should().Be(140);
+        excess.Target.Should().Be(100);
+        excess.Overshoot.Should().BeApproximately(40, Precision);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_SeveralOversuppliedElements_ReportsEachOne()
+    {
+        // Arrange
+        WaterProfile water = new WaterProfileBuilder()
+            .AddCa(140)
+            .AddMg(80)
+            .AddS(90)
+            .Build();
+
+        // Act
+        WaterAdjustedTarget result = Target().AdjustFor(water);
+
+        // Assert
+        result.Excesses.Select(e => e.Element).Should().BeEquivalentTo(["Ca", "Mg", "S"]);
+        result.Target.Ca.Value.Should().Be(0);
+        result.Target.Mg.Value.Should().Be(0);
+        result.Target.S.Value.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Water carrying an element the target never asked for is normal — sodium and chlorine are in most
+    /// supplies — and is not something the caller can act on, so it is not reported as an excess.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_WaterCarryingAnUnrequestedElement_IsNotAnExcess()
+    {
+        // Arrange: the target names no sodium or chlorine at all.
+        WaterProfile water = new WaterProfileBuilder().AddNa(35).AddCl(50).Build();
+
+        // Act
+        WaterAdjustedTarget result = Target().AdjustFor(water);
+
+        // Assert
+        result.HasExcesses.Should().BeFalse();
+        result.Target.Na.Value.Should().Be(0);
+        result.Target.Cl.Value.Should().Be(0);
+    }
+
+    // ---------------------------------------------------------------- end to end
+
+    /// <summary>
+    /// The whole point of the feature: the adjusted target is an ordinary <see cref="PpmTarget"/>, so it
+    /// goes straight into the optimizer, and the resulting mix plus the water lands on the original
+    /// target rather than overshooting it.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void AdjustedTarget_FedToTheOptimizer_LandsOnTheOriginalTargetOnceWaterIsAddedBack()
+    {
+        // Arrange
+        PpmTarget original = Target();
+        WaterProfile water = new WaterProfileBuilder().AddCa(40).AddMg(12).AddS(15).Build();
+        WaterAdjustedTarget adjusted = original.AdjustFor(water);
+
+        // Act
+        Solutions solutions = NpkTools.CreateOptimizationService().FindMacroSolutions(adjusted.Target);
+
+        // Assert
+        solutions.Should().NotBeEmpty();
+
+        Solution mix = solutions[0];
+        Ppm fromFertilizer = NpkTools.CreatePpmCalculator().CalculatePpm(mix, mix.WaterLiters);
+
+        (fromFertilizer.Calcium.Value + water.Calcium.Value).Should().BeApproximately(original.Ca.Value, 0.5);
+        (fromFertilizer.Magnesium.Value + water.Magnesium.Value).Should().BeApproximately(original.Mg.Value, 0.5);
+    }
+
+    // ---------------------------------------------------------------- guards
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_NullWater_ThrowsArgumentNullException()
+    {
+        Action act = () => Target().AdjustFor(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AdjustFor_NullTarget_ThrowsArgumentNullException()
+    {
+        Action act = () => ((PpmTarget)null!).AdjustFor(WaterProfile.Pure);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void WaterProfileBuilder_SettingAnElementTwice_Throws()
+    {
+        Action act = () => new WaterProfileBuilder().AddCa(10).AddCa(20).Build();
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void WaterProfileBuilder_NegativeValue_Throws()
+    {
+        Action act = () => new WaterProfileBuilder().AddCa(-1).Build();
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void WaterProfilePure_IsAllZero()
+    {
+        WaterProfile.Pure.Calcium.Value.Should().Be(0);
+        WaterProfile.Pure.Nitrogen.Value.Should().Be(0);
+        WaterProfile.Pure.Sodium.Value.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## What does this change?

Six features that turn a linear-program solver into something a grower can act on, plus the reference data
they need and a pre-release review pass. Cuts `1.0.0-preview.3`.

| Feature | What it adds |
| --- | --- |
| Source water | `target.AdjustFor(water)` — without it a hard supply overshoots calcium by 45% |
| Judging the mix | `ppm.Ratios()` and `solution.Breakdown(calculator)` |
| Own salts | `NpkTools.CreateOptimizationService(shelf)` — several recipes from a personal shelf, not one |
| A/B concentrates | `mix.AsConcentrate(liters)` — tanks, dilution ratio, dose per litre |
| mM / meq/L | The units the literature uses, plus the charge balance |
| EC | Predicts the meter reading, from the ions |

Three things in here were decided by measurement rather than design, and the reasoning is recorded in the
changelog because in each case the first attempt was wrong:

- **Bundle generation.** Building bundles up from per-element choices scored **5** distinct recipes against
  the hand-written catalogue's 19. Six simultaneous element targets need at least six salts to satisfy at
  non-negative weights, and such a bundle rarely has six once overlaps collapse. Plain hold-one-out scores
  **21** with far less machinery, so the first implementation was replaced rather than tuned.
- **The charge balance.** Documented at first as an error check. It is not: 14 of the 17 macro salts balance
  to exactly zero and the three that do not are precisely the three with acid-base character, so the number
  says whether a recipe needs more or less pH-down.
- **Solubility.** A per-salt check alone passed a 1:500 concentrate reaching 610 g/L with every salt inside
  its own limit. Salts compete for the same water, so a summed-saturation screen was added.

## Related issue

Not applicable.

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change (requires a major version bump and a CHANGELOG migration note)
- [x] Documentation

Not a breaking API change, but **behaviour changes**: three solubility figures were corrected, so a
concentrate that `preview.2` passed may now be refused. That is the point of the correction — two of the three
were wrong in the direction that passes a tank which cannot dissolve.

## Checklist

- [x] `dotnet build` is clean — the build treats warnings as errors
- [x] `dotnet test` passes — 601 tests (was 442)
- [x] New or changed behaviour is covered by tests
- [x] Public API changes carry XML documentation
- [x] `CHANGELOG.md` is updated for anything user-visible

## On the reference data

57 physical constants were added, and all were checked against published sources rather than taken on trust.

**Verified clean:** the 16 atomic weights against the IUPAC standard values; the 10 molar conductivities
against the CRC infinite-dilution table cross-checked against a second compilation. The EC model is anchored
on the certified KCl conductivity standards and comes out at **+0.1%** (0.001 M) and **+0.3%** (0.01 M), which
bracket a real feed, and −3.9% at 0.1 M — all three asserted, including the failing one, so the boundary of
usefulness lives in the suite rather than in a comment.

**Three solubility figures were wrong and are corrected:**

| Salt | Was | Now | Why |
| --- | --- | --- | --- |
| Ammonium nitrate | 1500 | 1920 | the 10 °C figure had been used, not the 20 °C one |
| Magnesium nitrate hexahydrate | 1250 | 420 | the anhydrous salt's figure under the hydrate's name |
| Zinc sulfate monohydrate | 600 | 350 | same, and the heptahydrate's 965 is also in circulation |

The cause was the basis, not the arithmetic: handbooks report a hydrate either as the hydrate or as the
anhydrous salt inside it, and for magnesium sulfate those differ by a factor of two. The table now states its
basis explicitly and carries each published `g per 100 mL` entry as a trailing comment. All 21 figures are now
pinned by test, plus the table's size — the earlier test pinned only the five lowest, and none of the three
wrong values was among them, so the suite passed while the table was wrong.

**13 of the catalogue's 34 salts deliberately carry no figure** — the EDTA chelates, calcium chloride
hexahydrate, urea phosphate, the nitrate micro salts and others — because published values for them disagree
by more than the check is worth. They report as `UnknownSolubility` rather than passing as safe.

## Pre-release review

An adversarial review before publishing found three defects in the new code. All were reproduced, fixed and
pinned by regression test; **the existing suite had passed over all three**.

- `MaxDilutionRatio` discarded the limits it knew when a tank held one salt it did not, reporting 1:1290 for a
  tank whose MKP stops dissolving near 1:45 — a factor of 28 in the direction that ruins a batch.
- The conductivity estimate went non-monotonic past an ionic strength of ~1.1 and hit exactly zero near 3.3,
  so a saturated solution reported no conductivity at all, silently. That range is reachable through the
  library's own concentrate path. The correction is now frozen at the top of the anchored range and
  `IsWithinValidatedRange` says when the figure is an ordering rather than a measurement.
- A stale figure in the shipped XML docs quoted 456 µS/cm where the code, README and tests say 454.

## After merge

The release needs tag `v1.0.0-preview.3` on `main`; the workflow refuses to publish if the tag does not match
the committed `<Version>`. Tag pushes are blocked from the environment this branch was developed in, so the
tag has to be created from the GitHub UI or a local clone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFyDNzAAodoHV5rrc8X46v)_