### PR TITLE
Two or four across, never three, and no sideways scrolling

### DIFF
--- a/web/SYT.NPKTools.Calculator/Components/CustomSaltForm.razor
+++ b/web/SYT.NPKTools.Calculator/Components/CustomSaltForm.razor
@@ -53,7 +53,7 @@
 }
 else
 {
-    <div class="field-grid" style="margin-top:var(--grid-gap); grid-template-columns:repeat(3,1fr)">
+    <div class="field-grid" style="margin-top:var(--grid-gap); --cols:3">
         @foreach (string form in CustomSalt.Forms)
         {
             <div class="field">
@@ -70,7 +70,7 @@ else
     </p>
 }
 
-<div class="field-grid" style="margin-top:var(--grid-gap); grid-template-columns:repeat(2,1fr)">
+<div class="field-grid" style="margin-top:var(--grid-gap); --cols:2">
     <div class="field">
         <label for="cs-tank">Concentrate tank</label>
         <select id="cs-tank" value="@_tank" @onchange="OnTankChanged">

--- a/web/SYT.NPKTools.Calculator/Components/ElementGrid.razor
+++ b/web/SYT.NPKTools.Calculator/Components/ElementGrid.razor
@@ -3,7 +3,7 @@
     because two implementations of the same grid drift apart within a month.
 *@
 
-<div class="field-grid" style="@(Columns is { } columns ? $"grid-template-columns:repeat({columns},1fr)" : null)">
+<div class="field-grid" style="@(Columns is { } columns ? $"--cols:{columns}" : null)">
     @foreach (string element in Elements)
     {
         <div class="field">

--- a/web/SYT.NPKTools.Calculator/Components/RecipeCard.razor
+++ b/web/SYT.NPKTools.Calculator/Components/RecipeCard.razor
@@ -14,8 +14,7 @@
         <span class="omits">@Recipe.Mix.Sum(f => f.Weight.Value).ToString("F1") g total</span>
     </div>
 
-    <div class="table-scroll">
-        <table>
+    <div class="table-scroll"><table>
             <thead>
                 <tr>
                     <th scope="col">Salt</th>
@@ -42,14 +41,12 @@
                     <td colspan="2"></td>
                 </tr>
             </tfoot>
-        </table>
-    </div>
+        </table></div>
 
     @* ------------------------------------------------------------------ achieved vs target *@
     <details style="margin-top:8px">
         <summary>In the reservoir — salts plus source water</summary>
-        <div class="table-scroll" style="margin-top:6px">
-            <table>
+        <div class="table-scroll" style="margin-top:6px"><table>
                 <thead>
                     <tr>
                         <th scope="col">Element</th>
@@ -75,8 +72,7 @@
                         </tr>
                     }
                 </tbody>
-            </table>
-        </div>
+            </table></div>
     </details>
 
     @* ------------------------------------------------------------------ interpretation *@

--- a/web/SYT.NPKTools.Calculator/Components/WaterPanel.razor
+++ b/web/SYT.NPKTools.Calculator/Components/WaterPanel.razor
@@ -46,7 +46,7 @@
             </select>
         </div>
 
-        <div class="field-grid" style="margin-top:var(--grid-gap)">
+        <div class="field-grid" style="margin-top:var(--grid-gap); --cols:2">
             <div class="field">
                 <label for="w-ec">Meter reading</label>
                 <input id="w-ec" type="number" min="0" step="0.01" value="@Model.WaterEc"
@@ -64,7 +64,7 @@
 
         @if (Model.Mode == WaterInputMode.ConductivityWithTests)
         {
-            <div class="field-grid" style="margin-top:var(--grid-gap)">
+            <div class="field-grid" style="margin-top:var(--grid-gap); --cols:2">
                 <div class="field">
                     <label for="w-gh">GH, °dH</label>
                     <input id="w-gh" type="number" min="0" step="0.5" value="@Model.WaterGh"
@@ -86,7 +86,7 @@
         {
             <div class="group-divider">Estimated analysis — not an analysis</div>
             @* Three across, so the six read as two rows rather than four and a stray pair. *@
-            <div class="field-grid" style="grid-template-columns:repeat(3,1fr)">
+            <div class="field-grid" style="--cols:3">
                 @foreach ((string symbol, double value) in Estimated(estimate))
                 {
                     <div class="field">

--- a/web/SYT.NPKTools.Calculator/wwwroot/css/app.css
+++ b/web/SYT.NPKTools.Calculator/wwwroot/css/app.css
@@ -153,7 +153,10 @@ body {
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(12, 1fr);
+  /* minmax(0,1fr) rather than 1fr: a bare fr floors at min-content, so one wide recipe table was
+     stretching all twelve tracks and pushing the whole page — input cards included — past the edge
+     of a phone screen. */
+  grid-template-columns: repeat(12, minmax(0, 1fr));
   gap: var(--grid-gap);
 }
 
@@ -195,9 +198,13 @@ body {
 
 /* ---------------------------------------------------------------- forms */
 
+/* Column count comes from --cols so a media query can override it; an inline
+   grid-template-columns could not be beaten without !important. minmax(0,1fr) rather than 1fr,
+   because a bare 1fr floors at min-content and lets long labels push the card wider than the
+   screen. */
 .field-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(76px, 1fr));
+  grid-template-columns: repeat(var(--cols, 4), minmax(0, 1fr));
   gap: var(--grid-gap);
 }
 
@@ -393,10 +400,22 @@ tfoot td:first-child { text-align: left; font-family: var(--font-ui); }
 
 /* ---------------------------------------------------------------- metrics */
 
+/*
+  Four readings go four across or two by two — never three and a stray one below, which is what
+  auto-fit gave on a phone.
+
+  Keyed to the card rather than the window, because the two columns of this layout are nothing like
+  each other: at 1440px the left column is about 460px and the right about 940px, and a window-width
+  rule would give both the same answer and be wrong for one of them.
+*/
 .metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(94px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--grid-gap);
+}
+
+@container (min-width: 460px) {
+  .metrics { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }
 
 .metric {
@@ -652,3 +671,76 @@ button.tiny {
 }
 
 .salt-row button.tiny + .formula { margin-left: 8px; }
+
+/* ---------------------------------------------------------------- narrow screens */
+
+/*
+  A phone gets two columns everywhere, whatever a component asked for. Six macronutrients then read
+  three rows of two rather than two rows of three squeezed to 90px, and nothing is ever left as a
+  single orphan on its own row.
+*/
+
+@media (max-width: 620px) {
+  .field-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+
+  /* Four labels do not fit across a phone. Two by two, and each keeps a real touch target. */
+  .segmented { flex-wrap: wrap; }
+  .segmented > button { flex: 1 1 calc(50% - 1px); }
+  .segmented > button:nth-child(2n) { border-left: 1px solid var(--border); }
+  .segmented > button:nth-child(n + 3) { border-top: 1px solid var(--border); }
+
+  .button-row { flex-wrap: wrap; }
+  .button-row > * { flex: 1 1 calc(50% - 4px); }
+}
+
+/* Long words in a note must wrap rather than widen the card. The page may scroll down; it must
+   never scroll sideways. */
+
+.card-note,
+.salt-row span,
+.notice span { overflow-wrap: anywhere; }
+
+html,
+body { overflow-x: hidden; }
+
+/* A recipe table has a floor below which its columns stop making sense, so it scrolls inside its
+   own card rather than widening the page. Sideways scrolling belongs to the table, never the body. */
+
+.card table { min-width: 320px; }
+
+.table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* A grid item's automatic minimum size is min-content, so a column refuses to be narrower than its
+   widest child no matter how small the tracks get. This is the rule that actually stops the page
+   scrolling sideways on a phone; minmax(0,1fr) on the tracks alone does not. */
+
+.col-4,
+.col-8,
+.col-12,
+.stack > * { min-width: 0; }
+
+/* ---------------------------------------------------------------- container queries */
+
+/* Every card measures itself, so a grid narrows because its own card is narrow rather than because
+   the window is. The left column stays about 460px wide from 1024px upwards while the window keeps
+   growing, and only the card knows that. */
+
+/* Recipes are <article class="recipe">, not cards, and they hold the widest readings on the page —
+   leaving them out meant the metrics never saw a container and stayed two across on a 1920 screen. */
+.card,
+.recipe { container-type: inline-size; }
+
+@container (max-width: 420px) {
+  .field-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+
+  .segmented { flex-wrap: wrap; }
+  .segmented > button { flex: 1 1 calc(50% - 1px); }
+  .segmented > button:nth-child(2n) { border-left: 1px solid var(--border); }
+  .segmented > button:nth-child(n + 3) { border-top: 1px solid var(--border); }
+
+  .button-row { flex-wrap: wrap; }
+  .button-row > * { flex: 1 1 calc(50% - 4px); }
+}


### PR DESCRIPTION
## What does this change?

A phone screenshot showed the four reservoir readings — EC, TDS, acid added, ions — rendering three
across with the fourth stranded alone on the next row. They now go **two by two or four across,
never three**.

The rules are keyed to the **card**, not the window. The two columns of this layout are nothing
alike: at 1440px the left one is about 460px and the right about 940px, so a window-width media
query gives both the same answer and is wrong for one of them. Recipes are `<article class="recipe">`
rather than `.card`, so they had to be named as containers too — without that the metrics stayed two
across on a 1920px screen.

## Two bugs found while measuring

Both the same classic trap, and both real:

- `1fr` floors at min-content, and a grid item's automatic minimum size is also min-content. One wide
  recipe table was stretching all twelve tracks of the page grid and pushing the **input cards** off
  the side of a phone. `minmax(0, 1fr)` on the tracks plus `min-width: 0` on the columns holds the
  page inside the screen.
- The table itself now scrolls inside its own card. Sideways scrolling belongs to the table; the page
  should only ever scroll down.

## How it was checked

Fifteen widths from 320 to 1920, driven through headless Chrome over the DevTools protocol —
measured, not eyeballed: viewport width, the right edge of every element outside a scroll container,
and the computed column count of every grid.

| | |
|---|---|
| Horizontal overflow | none at any width |
| Three-column layouts | none |
| Metrics | 2 up to 430px, 4 from 540px |
| Element grids | 2 on phones, declared counts when the card has room |

Worth recording for whoever does this next: `--window-size` **refuses to go below 500 CSS px** and
silently crops the screenshot instead. A "375px" screenshot is a 500px page cut to 375, which looks
exactly like a broken layout. Three fixes went into chasing that phantom before the measurement
returned `inner=500` for a window asked to be 375. `Emulation.setDeviceMetricsOverride` is the only
way to see a real phone width.

## Type of change

- [x] Bug fix

## Checklist

- [x] `dotnet build` is clean — the build treats warnings as errors
- [x] `dotnet test` passes — 739 tests
- [ ] New or changed behaviour is covered by tests — CSS layout, verified by measurement instead
- [x] Public API changes carry XML documentation — none
- [ ] `CHANGELOG.md` updated — a layout fix to unreleased work already in the Unreleased section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam