### PR TITLE
The app owns its error messages

### DIFF
--- a/tests/SYT.NPKTools.Calculator.Tests/ErrorMessageTests.cs
+++ b/tests/SYT.NPKTools.Calculator.Tests/ErrorMessageTests.cs
@@ -1,0 +1,82 @@
+using AwesomeAssertions;
+using Xunit;
+
+namespace SYT.NPKTools.Calculator.Tests;
+
+/// <summary>
+/// Covers the app owning its own error messages.
+/// </summary>
+/// <remarks>
+/// The model used to surface exception text straight from the library, which is written for developers
+/// and exists only in English. A grower needs a sentence they can act on, in their own language, so the
+/// app names the failure and translates it itself.
+/// </remarks>
+public class ErrorMessageTests
+{
+    /// <summary>A malformed target names the failure rather than passing the exception through.</summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void TargetText_WhenMalformed_SetsAKeyNotLibraryProse()
+    {
+        CalculatorModel model = new();
+
+        model.TargetText = "N=oops K=210";
+
+        model.ErrorKey.Should().Be("error.target.unreadable");
+    }
+
+    /// <summary>An empty shelf is its own failure, distinct from a malformed target.</summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Recalculate_WithNoSaltsSelected_SetsItsOwnKey()
+    {
+        CalculatorModel model = new();
+        model.Selected.Clear();
+
+        model.Recalculate();
+
+        model.ErrorKey.Should().Be("error.shelf.empty");
+    }
+
+    /// <summary>A target the shelf cannot reach is a third, different failure.</summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Recalculate_WhenNothingSuppliesAnElement_SetsTheUncoveredKey()
+    {
+        CalculatorModel model = new();
+        model.Selected.Clear();
+        model.Selected.Add("Potassium Nitrate");
+
+        model.Recalculate();
+
+        model.ErrorKey.Should().Be("error.recipe.uncovered");
+    }
+
+    /// <summary>A working setup reports nothing.</summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Recalculate_WhenItWorks_HasNoError()
+    {
+        CalculatorModel model = new();
+
+        model.Recalculate();
+
+        model.ErrorKey.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Fixing a malformed target clears the failure rather than leaving it on screen.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void TargetText_WhenCorrected_ClearsTheKey()
+    {
+        CalculatorModel model = new();
+        model.TargetText = "N=oops";
+        model.ErrorKey.Should().NotBeNull();
+
+        model.TargetText = "N=150 K=210 L=100";
+
+        model.ErrorKey.Should().BeNull();
+    }
+}

--- a/web/SYT.NPKTools.Calculator/CalculatorModel.cs
+++ b/web/SYT.NPKTools.Calculator/CalculatorModel.cs
@@ -149,10 +149,12 @@ public sealed class CalculatorModel
             catch (Exception ex) when (ex is ArgumentException or FormatException or InvalidOperationException)
             {
                 Error = ex.Message;
+                ErrorKey = "error.target.unreadable";
                 return;
             }
 
             Error = null;
+            ErrorKey = null;
             Liters = parsed.Liters.Value;
             foreach (string symbol in ElementGroups.All)
             {
@@ -300,6 +302,17 @@ public sealed class CalculatorModel
     /// <summary>The inferred analysis, or null when the water was not estimated.</summary>
     public WaterEstimate? WaterEstimate { get; private set; }
 
+    /// <summary>
+    /// Which failure this is, as a translation key, or null when there is none.
+    /// </summary>
+    /// <remarks>
+    /// Named rather than described, because the library's exception text is written for developers and
+    /// exists only in English. A grower needs a sentence they can act on, in their own language, so the
+    /// app names the condition and writes its own. <see cref="UncoveredElements"/> carries the detail
+    /// the message needs to name.
+    /// </remarks>
+    public string? ErrorKey { get; private set; }
+
     /// <summary>The acid plan, or null when no acid is needed or wanted.</summary>
     public AcidPlan? Acid { get; private set; }
 
@@ -327,6 +340,7 @@ public sealed class CalculatorModel
     {
         HasRun = true;
         Error = null;
+        ErrorKey = null;
         Recipes = [];
         Excesses = [];
         UncoveredElements = [];
@@ -355,6 +369,7 @@ public sealed class CalculatorModel
         catch (Exception ex) when (ex is ArgumentException or FormatException or InvalidOperationException)
         {
             Error = ex.Message;
+            ErrorKey = "error.target.unreadable";
             Target = null;
             return;
         }
@@ -365,6 +380,7 @@ public sealed class CalculatorModel
         if (shelf.Length == 0)
         {
             Error = "No salts selected. Tick at least one.";
+            ErrorKey = "error.shelf.empty";
             return;
         }
 
@@ -384,6 +400,7 @@ public sealed class CalculatorModel
             Error = UncoveredElements.Count > 0
                 ? $"No recipe: nothing on the shelf supplies {string.Join(", ", UncoveredElements)}."
                 : "No recipe. The selected salts cannot reach this target — try adding more, or relax it.";
+            ErrorKey = UncoveredElements.Count > 0 ? "error.recipe.uncovered" : "error.recipe.unreachable";
             return;
         }
 

--- a/web/SYT.NPKTools.Calculator/Pages/Home.razor
+++ b/web/SYT.NPKTools.Calculator/Pages/Home.razor
@@ -1,5 +1,6 @@
 @page "/"
 @inject CalculatorModel Model
+@inject Translations T
 
 <PageTitle>NPKTools — fertilizer calculator</PageTitle>
 
@@ -28,11 +29,14 @@
                 </p>
             </details>
 
-            @if (Model.Error is not null)
+            @if (Model.ErrorKey is { } errorKey)
             {
                 <div class="notice error" role="alert">
                     <Icon Kind="IconKind.Error" />
-                    <span><strong>Cannot solve.</strong> @Model.Error</span>
+                    <span>
+                        <strong>@T["target.cannotSolve"]</strong>
+                        @T[errorKey].Replace("{0}", string.Join(", ", Model.UncoveredElements), StringComparison.Ordinal)
+                    </span>
                 </div>
             }
         </section>

--- a/web/SYT.NPKTools.Calculator/Resources/de.json
+++ b/web/SYT.NPKTools.Calculator/Resources/de.json
@@ -31,5 +31,10 @@
   "acid.overshoot.alternative": "{0} would fit.",
   "acid.note": "The {0} above is deducted from the target, like the water. Worked for a closed vessel: an open reservoir loses CO₂ and drifts back up, so the dose you settle on will be nearer the full {1} meq/L. Each recipe's EC still counts this water's bicarbonate, which the acid removes, so it reads high once you have acidified — by roughly {2} µS/cm.",
   "notFound.title": "Something went wrong.",
-  "notFound.reload": "Reload"
+  "notFound.reload": "Reload",
+  "error.target.unreadable": "That target cannot be read. Use element=ppm pairs separated by spaces, for example N=150 K=210 L=100.",
+  "error.shelf.empty": "No salts selected. Tick at least one.",
+  "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
+  "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
+  "target.cannotSolve": "Cannot solve."
 }

--- a/web/SYT.NPKTools.Calculator/Resources/en.json
+++ b/web/SYT.NPKTools.Calculator/Resources/en.json
@@ -31,5 +31,10 @@
   "acid.overshoot.alternative": "{0} would fit.",
   "acid.note": "The {0} above is deducted from the target, like the water. Worked for a closed vessel: an open reservoir loses CO₂ and drifts back up, so the dose you settle on will be nearer the full {1} meq/L. Each recipe's EC still counts this water's bicarbonate, which the acid removes, so it reads high once you have acidified — by roughly {2} µS/cm.",
   "notFound.title": "Something went wrong.",
-  "notFound.reload": "Reload"
+  "notFound.reload": "Reload",
+  "error.target.unreadable": "That target cannot be read. Use element=ppm pairs separated by spaces, for example N=150 K=210 L=100.",
+  "error.shelf.empty": "No salts selected. Tick at least one.",
+  "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
+  "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
+  "target.cannotSolve": "Cannot solve."
 }

--- a/web/SYT.NPKTools.Calculator/Resources/es.json
+++ b/web/SYT.NPKTools.Calculator/Resources/es.json
@@ -31,5 +31,10 @@
   "acid.overshoot.alternative": "{0} would fit.",
   "acid.note": "The {0} above is deducted from the target, like the water. Worked for a closed vessel: an open reservoir loses CO₂ and drifts back up, so the dose you settle on will be nearer the full {1} meq/L. Each recipe's EC still counts this water's bicarbonate, which the acid removes, so it reads high once you have acidified — by roughly {2} µS/cm.",
   "notFound.title": "Something went wrong.",
-  "notFound.reload": "Reload"
+  "notFound.reload": "Reload",
+  "error.target.unreadable": "That target cannot be read. Use element=ppm pairs separated by spaces, for example N=150 K=210 L=100.",
+  "error.shelf.empty": "No salts selected. Tick at least one.",
+  "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
+  "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
+  "target.cannotSolve": "Cannot solve."
 }

--- a/web/SYT.NPKTools.Calculator/Resources/nl.json
+++ b/web/SYT.NPKTools.Calculator/Resources/nl.json
@@ -31,5 +31,10 @@
   "acid.overshoot.alternative": "{0} would fit.",
   "acid.note": "The {0} above is deducted from the target, like the water. Worked for a closed vessel: an open reservoir loses CO₂ and drifts back up, so the dose you settle on will be nearer the full {1} meq/L. Each recipe's EC still counts this water's bicarbonate, which the acid removes, so it reads high once you have acidified — by roughly {2} µS/cm.",
   "notFound.title": "Something went wrong.",
-  "notFound.reload": "Reload"
+  "notFound.reload": "Reload",
+  "error.target.unreadable": "That target cannot be read. Use element=ppm pairs separated by spaces, for example N=150 K=210 L=100.",
+  "error.shelf.empty": "No salts selected. Tick at least one.",
+  "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
+  "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
+  "target.cannotSolve": "Cannot solve."
 }

--- a/web/SYT.NPKTools.Calculator/Resources/pl.json
+++ b/web/SYT.NPKTools.Calculator/Resources/pl.json
@@ -31,5 +31,10 @@
   "acid.overshoot.alternative": "{0} would fit.",
   "acid.note": "The {0} above is deducted from the target, like the water. Worked for a closed vessel: an open reservoir loses CO₂ and drifts back up, so the dose you settle on will be nearer the full {1} meq/L. Each recipe's EC still counts this water's bicarbonate, which the acid removes, so it reads high once you have acidified — by roughly {2} µS/cm.",
   "notFound.title": "Something went wrong.",
-  "notFound.reload": "Reload"
+  "notFound.reload": "Reload",
+  "error.target.unreadable": "That target cannot be read. Use element=ppm pairs separated by spaces, for example N=150 K=210 L=100.",
+  "error.shelf.empty": "No salts selected. Tick at least one.",
+  "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
+  "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
+  "target.cannotSolve": "Cannot solve."
 }

--- a/web/SYT.NPKTools.Calculator/Resources/ru.json
+++ b/web/SYT.NPKTools.Calculator/Resources/ru.json
@@ -31,5 +31,10 @@
   "acid.overshoot.alternative": "{0} would fit.",
   "acid.note": "The {0} above is deducted from the target, like the water. Worked for a closed vessel: an open reservoir loses CO₂ and drifts back up, so the dose you settle on will be nearer the full {1} meq/L. Each recipe's EC still counts this water's bicarbonate, which the acid removes, so it reads high once you have acidified — by roughly {2} µS/cm.",
   "notFound.title": "Something went wrong.",
-  "notFound.reload": "Reload"
+  "notFound.reload": "Reload",
+  "error.target.unreadable": "That target cannot be read. Use element=ppm pairs separated by spaces, for example N=150 K=210 L=100.",
+  "error.shelf.empty": "No salts selected. Tick at least one.",
+  "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
+  "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
+  "target.cannotSolve": "Cannot solve."
 }

--- a/web/SYT.NPKTools.Calculator/Resources/tr.json
+++ b/web/SYT.NPKTools.Calculator/Resources/tr.json
@@ -31,5 +31,10 @@
   "acid.overshoot.alternative": "{0} would fit.",
   "acid.note": "The {0} above is deducted from the target, like the water. Worked for a closed vessel: an open reservoir loses CO₂ and drifts back up, so the dose you settle on will be nearer the full {1} meq/L. Each recipe's EC still counts this water's bicarbonate, which the acid removes, so it reads high once you have acidified — by roughly {2} µS/cm.",
   "notFound.title": "Something went wrong.",
-  "notFound.reload": "Reload"
+  "notFound.reload": "Reload",
+  "error.target.unreadable": "That target cannot be read. Use element=ppm pairs separated by spaces, for example N=150 K=210 L=100.",
+  "error.shelf.empty": "No salts selected. Tick at least one.",
+  "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
+  "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
+  "target.cannotSolve": "Cannot solve."
 }

--- a/web/SYT.NPKTools.Calculator/Resources/uk.json
+++ b/web/SYT.NPKTools.Calculator/Resources/uk.json
@@ -31,5 +31,10 @@
   "acid.overshoot.alternative": "{0} would fit.",
   "acid.note": "The {0} above is deducted from the target, like the water. Worked for a closed vessel: an open reservoir loses CO₂ and drifts back up, so the dose you settle on will be nearer the full {1} meq/L. Each recipe's EC still counts this water's bicarbonate, which the acid removes, so it reads high once you have acidified — by roughly {2} µS/cm.",
   "notFound.title": "Something went wrong.",
-  "notFound.reload": "Reload"
+  "notFound.reload": "Reload",
+  "error.target.unreadable": "That target cannot be read. Use element=ppm pairs separated by spaces, for example N=150 K=210 L=100.",
+  "error.shelf.empty": "No salts selected. Tick at least one.",
+  "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
+  "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
+  "target.cannotSolve": "Cannot solve."
 }


### PR DESCRIPTION
## What does this change?

`CalculatorModel` set `Error = ex.Message`, so any of the 242 English exception strings from the
`SYT.NPKTools` NuGet package could land in front of a grower.

Localising them inside the library would be the wrong fix: those messages are an API for developers,
and a consumer catching an exception should not receive Ukrainian.

So the app names the condition and writes its own sentence. Four failures, four keys:

| Condition | What it now says |
|---|---|
| malformed target | "That target cannot be read. Use element=ppm pairs separated by spaces, for example N=150 K=210 L=100." |
| nothing ticked | "No salts selected. Tick at least one." |
| an element nothing supplies | "Nothing on the shelf supplies {0}." |
| target out of reach | "The selected salts cannot reach this target. Add more, or relax it." |

Better independently of translation: the messages are now ones a grower can act on rather than ones a
developer wrote for themselves.

`Error` keeps carrying the English text so nothing reading it breaks; the interface reads `ErrorKey`.

## Tests

Five cases, including the one that matters after a fix: correcting a malformed target clears the
failure rather than leaving it on screen.

## Type of change

- [x] Bug fix
- [x] New feature

## Checklist

- [x] `dotnet build` is clean — the build treats warnings as errors
- [x] `dotnet test` passes — 799 tests
- [x] New or changed behaviour is covered by tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam