### PR TITLE
The main page behind keys, with two assembled sentences rebuilt

### DIFF
--- a/web/SYT.NPKTools.Calculator/Pages/Home.razor
+++ b/web/SYT.NPKTools.Calculator/Pages/Home.razor
@@ -2,7 +2,7 @@
 @inject CalculatorModel Model
 @inject Translations T
 
-<PageTitle>NPKTools — fertilizer calculator</PageTitle>
+<PageTitle>@T["page.title"]</PageTitle>
 
 <div class="grid">
 
@@ -10,9 +10,9 @@
     <div class="col-4 stack">
 
         <section class="card">
-            <h2>Target — macro</h2>
+            <h2>@T["target.macro.title"]</h2>
             <div class="field" style="margin-bottom:var(--grid-gap)">
-                <label for="liters">Reservoir, litres</label>
+                <label for="liters">@T["target.litres"]</label>
                 <input id="liters" type="number" min="0" step="1" value="@Model.Liters"
                        @onchange="OnLitersChanged" />
             </div>
@@ -20,13 +20,13 @@
                          Prefix="t" Step="1" Columns="3" Changed="_ => Edited()" />
 
             <details class="extra">
-                <summary>As a string</summary>
+                <summary>@T["target.asString"]</summary>
                 <input class="target-input" type="text" value="@Model.TargetText"
-                       @onchange="OnTargetChanged" aria-label="Target nutrient profile in ppm" />
-                <p class="card-note">
-                    Element=ppm, separated by spaces. <code>L</code> is the reservoir volume in litres.
-                    Paste one from a feed chart, or copy this one out.
-                </p>
+                       @onchange="OnTargetChanged" aria-label="@T["target.asString.aria"]" />
+                @* One key, not three fragments around a <code> element: word order differs across
+                   the eight languages, and the code styling is not worth making a sentence
+                   untranslatable. *@
+                <p class="card-note">@T["target.asString.note"]</p>
             </details>
 
             @if (Model.ErrorKey is { } errorKey)
@@ -42,12 +42,12 @@
         </section>
 
         <section class="card">
-            <h2>Target — micro</h2>
+            <h2>@T["target.micro.title"]</h2>
             <ElementGrid Elements="ElementGroups.Micro" Values="Model.TargetFields"
                          Prefix="t" Step="0.01" Columns="4" Changed="_ => Edited()" />
-            <div class="group-divider">Counter-ions</div>
+            <div class="group-divider">@T["target.counterIons"]</div>
             <p class="card-note" style="margin-top:0">
-                Not dosed for — they arrive with other salts — but a target may still name them.
+                @T["target.counterIons.note"]
             </p>
             <ElementGrid Elements="ElementGroups.CounterIons" Values="Model.TargetFields"
                          Prefix="t" Step="0.1" Columns="2" Changed="_ => Edited()" />
@@ -62,15 +62,14 @@
         <StoragePanel @ref="_storage" Changed="StateHasChanged" />
 
         <section class="card">
-            <h2>Concentrate</h2>
+            <h2>@T["concentrate.title"]</h2>
             <div class="field">
-                <label for="conc">Litres per tank — blank for none</label>
+                <label for="conc">@T["concentrate.litres"]</label>
                 <input id="conc" type="number" min="0" step="0.1" value="@Model.ConcentrateLiters"
                        @onchange="OnConcentrateChanged" />
             </div>
             <p class="card-note">
-                The whole recipe's salt goes into this much water, so a 100 L recipe in 1 L is 1:100.
-                Calcium is kept away from sulfate and phosphate.
+                @T["concentrate.note"]
             </p>
         </section>
 
@@ -80,19 +79,18 @@
     <div class="col-8">
         @if (!Model.HasRun)
         {
-            <div class="card empty">Enter a target and the calculator will work out the recipes.</div>
+            <div class="card empty">@T["recipes.empty.noRun"]</div>
         }
         else if (Model.Recipes.Count == 0)
         {
-            <div class="card empty">No recipe for this combination. See the message on the left.</div>
+            <div class="card empty">@T["recipes.empty.none"]</div>
         }
         else
         {
             <div class="card" style="margin-bottom:var(--grid-gap)">
-                <h2>@Model.Recipes.Count recipes — @(Model.Target!.Liters.Value.ToString("F0")) L</h2>
+                <h2>@RecipesTitle</h2>
                 <p class="card-note" style="margin-top:0">
-                    Every one of these hits the target. They differ in which salts they use, so pick by
-                    what you would rather spend, or by which figures below you prefer.
+                    @T["recipes.note"]
                 </p>
             </div>
 
@@ -107,6 +105,15 @@
 
 @code {
     private StoragePanel? _storage;
+
+    // Plural form and litres in one key: a translator cannot reorder a heading assembled in markup,
+    // and not every language puts the volume where English does.
+    private string RecipesTitle =>
+        T.Plural("recipes.title", Model.Recipes.Count)
+            .Replace(
+                "{1}",
+                Model.Target!.Liters.Value.ToString("F0", System.Globalization.CultureInfo.InvariantCulture),
+                StringComparison.Ordinal);
 
     protected override void OnInitialized() => Model.Recalculate();
 

--- a/web/SYT.NPKTools.Calculator/Resources/de.json
+++ b/web/SYT.NPKTools.Calculator/Resources/de.json
@@ -36,5 +36,24 @@
   "error.shelf.empty": "No salts selected. Tick at least one.",
   "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
   "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
-  "target.cannotSolve": "Cannot solve."
+  "target.cannotSolve": "Cannot solve.",
+  "page.title": "NPKTools — fertilizer calculator",
+  "target.macro.title": "Target — macro",
+  "target.micro.title": "Target — micro",
+  "target.litres": "Reservoir, litres",
+  "target.asString": "As a string",
+  "target.asString.aria": "Target nutrient profile in ppm",
+  "target.asString.note": "Element=ppm, separated by spaces. L is the reservoir volume in litres. Paste one from a feed chart, or copy this one out.",
+  "target.counterIons.note": "Not dosed for — they arrive with other salts — but a target may still name them.",
+  "concentrate.title": "Concentrate",
+  "concentrate.litres": "Litres per tank — blank for none",
+  "concentrate.note": "The whole recipe's salt goes into this much water, so a 100 L recipe in 1 L is 1:100. Calcium is kept away from sulfate and phosphate.",
+  "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
+  "recipes.empty.none": "No recipe for this combination. See the message on the left.",
+  "recipes.title": {
+    "one": "{0} recipe — {1} L",
+    "other": "{0} recipes — {1} L"
+  },
+  "recipes.note": "Every one of these hits the target. They differ in which salts they use, so pick by what you would rather spend, or by which figures below you prefer.",
+  "target.counterIons": "Counter-ions"
 }

--- a/web/SYT.NPKTools.Calculator/Resources/en.json
+++ b/web/SYT.NPKTools.Calculator/Resources/en.json
@@ -36,5 +36,24 @@
   "error.shelf.empty": "No salts selected. Tick at least one.",
   "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
   "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
-  "target.cannotSolve": "Cannot solve."
+  "target.cannotSolve": "Cannot solve.",
+  "page.title": "NPKTools — fertilizer calculator",
+  "target.macro.title": "Target — macro",
+  "target.micro.title": "Target — micro",
+  "target.litres": "Reservoir, litres",
+  "target.asString": "As a string",
+  "target.asString.aria": "Target nutrient profile in ppm",
+  "target.asString.note": "Element=ppm, separated by spaces. L is the reservoir volume in litres. Paste one from a feed chart, or copy this one out.",
+  "target.counterIons.note": "Not dosed for — they arrive with other salts — but a target may still name them.",
+  "concentrate.title": "Concentrate",
+  "concentrate.litres": "Litres per tank — blank for none",
+  "concentrate.note": "The whole recipe's salt goes into this much water, so a 100 L recipe in 1 L is 1:100. Calcium is kept away from sulfate and phosphate.",
+  "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
+  "recipes.empty.none": "No recipe for this combination. See the message on the left.",
+  "recipes.title": {
+    "one": "{0} recipe — {1} L",
+    "other": "{0} recipes — {1} L"
+  },
+  "recipes.note": "Every one of these hits the target. They differ in which salts they use, so pick by what you would rather spend, or by which figures below you prefer.",
+  "target.counterIons": "Counter-ions"
 }

--- a/web/SYT.NPKTools.Calculator/Resources/es.json
+++ b/web/SYT.NPKTools.Calculator/Resources/es.json
@@ -36,5 +36,24 @@
   "error.shelf.empty": "No salts selected. Tick at least one.",
   "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
   "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
-  "target.cannotSolve": "Cannot solve."
+  "target.cannotSolve": "Cannot solve.",
+  "page.title": "NPKTools — fertilizer calculator",
+  "target.macro.title": "Target — macro",
+  "target.micro.title": "Target — micro",
+  "target.litres": "Reservoir, litres",
+  "target.asString": "As a string",
+  "target.asString.aria": "Target nutrient profile in ppm",
+  "target.asString.note": "Element=ppm, separated by spaces. L is the reservoir volume in litres. Paste one from a feed chart, or copy this one out.",
+  "target.counterIons.note": "Not dosed for — they arrive with other salts — but a target may still name them.",
+  "concentrate.title": "Concentrate",
+  "concentrate.litres": "Litres per tank — blank for none",
+  "concentrate.note": "The whole recipe's salt goes into this much water, so a 100 L recipe in 1 L is 1:100. Calcium is kept away from sulfate and phosphate.",
+  "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
+  "recipes.empty.none": "No recipe for this combination. See the message on the left.",
+  "recipes.title": {
+    "one": "{0} recipe — {1} L",
+    "other": "{0} recipes — {1} L"
+  },
+  "recipes.note": "Every one of these hits the target. They differ in which salts they use, so pick by what you would rather spend, or by which figures below you prefer.",
+  "target.counterIons": "Counter-ions"
 }

--- a/web/SYT.NPKTools.Calculator/Resources/nl.json
+++ b/web/SYT.NPKTools.Calculator/Resources/nl.json
@@ -36,5 +36,24 @@
   "error.shelf.empty": "No salts selected. Tick at least one.",
   "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
   "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
-  "target.cannotSolve": "Cannot solve."
+  "target.cannotSolve": "Cannot solve.",
+  "page.title": "NPKTools — fertilizer calculator",
+  "target.macro.title": "Target — macro",
+  "target.micro.title": "Target — micro",
+  "target.litres": "Reservoir, litres",
+  "target.asString": "As a string",
+  "target.asString.aria": "Target nutrient profile in ppm",
+  "target.asString.note": "Element=ppm, separated by spaces. L is the reservoir volume in litres. Paste one from a feed chart, or copy this one out.",
+  "target.counterIons.note": "Not dosed for — they arrive with other salts — but a target may still name them.",
+  "concentrate.title": "Concentrate",
+  "concentrate.litres": "Litres per tank — blank for none",
+  "concentrate.note": "The whole recipe's salt goes into this much water, so a 100 L recipe in 1 L is 1:100. Calcium is kept away from sulfate and phosphate.",
+  "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
+  "recipes.empty.none": "No recipe for this combination. See the message on the left.",
+  "recipes.title": {
+    "one": "{0} recipe — {1} L",
+    "other": "{0} recipes — {1} L"
+  },
+  "recipes.note": "Every one of these hits the target. They differ in which salts they use, so pick by what you would rather spend, or by which figures below you prefer.",
+  "target.counterIons": "Counter-ions"
 }

--- a/web/SYT.NPKTools.Calculator/Resources/pl.json
+++ b/web/SYT.NPKTools.Calculator/Resources/pl.json
@@ -36,5 +36,24 @@
   "error.shelf.empty": "No salts selected. Tick at least one.",
   "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
   "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
-  "target.cannotSolve": "Cannot solve."
+  "target.cannotSolve": "Cannot solve.",
+  "page.title": "NPKTools — fertilizer calculator",
+  "target.macro.title": "Target — macro",
+  "target.micro.title": "Target — micro",
+  "target.litres": "Reservoir, litres",
+  "target.asString": "As a string",
+  "target.asString.aria": "Target nutrient profile in ppm",
+  "target.asString.note": "Element=ppm, separated by spaces. L is the reservoir volume in litres. Paste one from a feed chart, or copy this one out.",
+  "target.counterIons.note": "Not dosed for — they arrive with other salts — but a target may still name them.",
+  "concentrate.title": "Concentrate",
+  "concentrate.litres": "Litres per tank — blank for none",
+  "concentrate.note": "The whole recipe's salt goes into this much water, so a 100 L recipe in 1 L is 1:100. Calcium is kept away from sulfate and phosphate.",
+  "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
+  "recipes.empty.none": "No recipe for this combination. See the message on the left.",
+  "recipes.title": {
+    "one": "{0} recipe — {1} L",
+    "other": "{0} recipes — {1} L"
+  },
+  "recipes.note": "Every one of these hits the target. They differ in which salts they use, so pick by what you would rather spend, or by which figures below you prefer.",
+  "target.counterIons": "Counter-ions"
 }

--- a/web/SYT.NPKTools.Calculator/Resources/ru.json
+++ b/web/SYT.NPKTools.Calculator/Resources/ru.json
@@ -36,5 +36,24 @@
   "error.shelf.empty": "No salts selected. Tick at least one.",
   "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
   "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
-  "target.cannotSolve": "Cannot solve."
+  "target.cannotSolve": "Cannot solve.",
+  "page.title": "NPKTools — fertilizer calculator",
+  "target.macro.title": "Target — macro",
+  "target.micro.title": "Target — micro",
+  "target.litres": "Reservoir, litres",
+  "target.asString": "As a string",
+  "target.asString.aria": "Target nutrient profile in ppm",
+  "target.asString.note": "Element=ppm, separated by spaces. L is the reservoir volume in litres. Paste one from a feed chart, or copy this one out.",
+  "target.counterIons.note": "Not dosed for — they arrive with other salts — but a target may still name them.",
+  "concentrate.title": "Concentrate",
+  "concentrate.litres": "Litres per tank — blank for none",
+  "concentrate.note": "The whole recipe's salt goes into this much water, so a 100 L recipe in 1 L is 1:100. Calcium is kept away from sulfate and phosphate.",
+  "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
+  "recipes.empty.none": "No recipe for this combination. See the message on the left.",
+  "recipes.title": {
+    "one": "{0} recipe — {1} L",
+    "other": "{0} recipes — {1} L"
+  },
+  "recipes.note": "Every one of these hits the target. They differ in which salts they use, so pick by what you would rather spend, or by which figures below you prefer.",
+  "target.counterIons": "Counter-ions"
 }

--- a/web/SYT.NPKTools.Calculator/Resources/tr.json
+++ b/web/SYT.NPKTools.Calculator/Resources/tr.json
@@ -36,5 +36,24 @@
   "error.shelf.empty": "No salts selected. Tick at least one.",
   "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
   "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
-  "target.cannotSolve": "Cannot solve."
+  "target.cannotSolve": "Cannot solve.",
+  "page.title": "NPKTools — fertilizer calculator",
+  "target.macro.title": "Target — macro",
+  "target.micro.title": "Target — micro",
+  "target.litres": "Reservoir, litres",
+  "target.asString": "As a string",
+  "target.asString.aria": "Target nutrient profile in ppm",
+  "target.asString.note": "Element=ppm, separated by spaces. L is the reservoir volume in litres. Paste one from a feed chart, or copy this one out.",
+  "target.counterIons.note": "Not dosed for — they arrive with other salts — but a target may still name them.",
+  "concentrate.title": "Concentrate",
+  "concentrate.litres": "Litres per tank — blank for none",
+  "concentrate.note": "The whole recipe's salt goes into this much water, so a 100 L recipe in 1 L is 1:100. Calcium is kept away from sulfate and phosphate.",
+  "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
+  "recipes.empty.none": "No recipe for this combination. See the message on the left.",
+  "recipes.title": {
+    "one": "{0} recipe — {1} L",
+    "other": "{0} recipes — {1} L"
+  },
+  "recipes.note": "Every one of these hits the target. They differ in which salts they use, so pick by what you would rather spend, or by which figures below you prefer.",
+  "target.counterIons": "Counter-ions"
 }

--- a/web/SYT.NPKTools.Calculator/Resources/uk.json
+++ b/web/SYT.NPKTools.Calculator/Resources/uk.json
@@ -36,5 +36,24 @@
   "error.shelf.empty": "No salts selected. Tick at least one.",
   "error.recipe.uncovered": "Nothing on the shelf supplies {0}.",
   "error.recipe.unreachable": "The selected salts cannot reach this target. Add more, or relax it.",
-  "target.cannotSolve": "Cannot solve."
+  "target.cannotSolve": "Cannot solve.",
+  "page.title": "NPKTools — fertilizer calculator",
+  "target.macro.title": "Target — macro",
+  "target.micro.title": "Target — micro",
+  "target.litres": "Reservoir, litres",
+  "target.asString": "As a string",
+  "target.asString.aria": "Target nutrient profile in ppm",
+  "target.asString.note": "Element=ppm, separated by spaces. L is the reservoir volume in litres. Paste one from a feed chart, or copy this one out.",
+  "target.counterIons.note": "Not dosed for — they arrive with other salts — but a target may still name them.",
+  "concentrate.title": "Concentrate",
+  "concentrate.litres": "Litres per tank — blank for none",
+  "concentrate.note": "The whole recipe's salt goes into this much water, so a 100 L recipe in 1 L is 1:100. Calcium is kept away from sulfate and phosphate.",
+  "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
+  "recipes.empty.none": "No recipe for this combination. See the message on the left.",
+  "recipes.title": {
+    "one": "{0} recipe — {1} L",
+    "other": "{0} recipes — {1} L"
+  },
+  "recipes.note": "Every one of these hits the target. They differ in which salts they use, so pick by what you would rather spend, or by which figures below you prefer.",
+  "target.counterIons": "Counter-ions"
 }


### PR DESCRIPTION
## What does this change?

Sixteen strings on the main page move behind keys. Two of them were not strings at all but sentences
assembled at render time, and those are the part worth reviewing:

**The "As a string" note** had a `<code>L</code>` element inside it, splitting one sentence into three
text nodes. It is now one key. The code styling goes, and that is the right trade: word order differs
across the eight languages, and a sentence a translator cannot reorder is a sentence they cannot
translate.

**The recipes heading** was a count, the word "recipes", an em dash and a volume concatenated in
markup. It is now one key carrying a plural form and both values, because not every language puts the
volume where English does.

## How it was checked

Against the captured rendered text of the live site: **identical word for word**, apart from the
language picker, which the baseline predates.

The check earned its place on this pass. It caught `target.counterIons` rendering as its own key on
screen — I had added the note for that section and forgotten the heading. Which is the missing-key
fallback behaving exactly as designed: visible and reported, rather than a silent blank.

## Type of change

- [x] Documentation / refactor — no behaviour change

## Checklist

- [x] `dotnet build` is clean — the build treats warnings as errors
- [x] `dotnet test` passes — 799 tests
- [x] Rendered text verified unchanged against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam