### PR TITLE
The acidification card has never been visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   collapsed, and is still what links and files carry — so a typo in it no longer destroys the target.
 - Links carry the water and acid settings. Existing links keep working.
 
+### Fixed
+
+- The acidification card now appears when the water has alkalinity to neutralise. It never did:
+  Blazor does not re-render a child component whose parameters have not changed, and each panel takes
+  one — a callback to the same method on the page, equal on every pass — so a panel redrew only when it
+  handled the event itself. The card was drawn once at startup, on osmosis, where there is nothing to
+  neutralise, and was never drawn again. The acid dose, the overshoot warning and the note about an
+  open reservoir were all unreachable. The model now announces each recalculation and every panel
+  listens, which also fixes a stale download link: the file offered was the setup as it stood when the
+  page opened.
+
 ## [1.0.0-preview.3] - 2026-08-01
 
 **The calculator, not just the solver.** Everything below turns a recipe into something a grower can act on:

--- a/tests/SYT.NPKTools.Calculator.Tests/RedrawTests.cs
+++ b/tests/SYT.NPKTools.Calculator.Tests/RedrawTests.cs
@@ -1,0 +1,75 @@
+using AwesomeAssertions;
+using Xunit;
+
+namespace SYT.NPKTools.Calculator.Tests;
+
+/// <summary>
+/// Covers the model announcing that it has changed.
+/// </summary>
+/// <remarks>
+/// Blazor does not re-render a child component whose parameters have not changed, and every panel on
+/// this page takes one parameter — a callback to the same method on the same page, equal on every
+/// pass. So each panel only redrew when it handled the event itself, and the acidification card, which
+/// appears when the water has alkalinity, was drawn once at startup on osmosis and never again. These
+/// tests cover the announcement; that the panels listen to it is markup, and shows up in the browser.
+/// </remarks>
+public class RedrawTests
+{
+    /// <summary>
+    /// A recalculation tells whoever is listening.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Recalculate_RaisesChanged()
+    {
+        CalculatorModel model = new();
+        int raised = 0;
+        model.Changed += () => raised++;
+
+        model.Recalculate();
+
+        raised.Should().Be(1);
+    }
+
+    /// <summary>
+    /// A recalculation that fails still tells them, because a stale screen is worse than a lost
+    /// calculation.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Recalculate_WhenItCannotSolve_StillRaisesChanged()
+    {
+        CalculatorModel model = new();
+        model.Selected.Clear();
+        int raised = 0;
+        model.Changed += () => raised++;
+
+        model.Recalculate();
+
+        model.ErrorKey.Should().Be("error.shelf.empty");
+        raised.Should().Be(1);
+    }
+
+    /// <summary>
+    /// The alkalinity the acidification card keys off is set by the recalculation that announces it,
+    /// so a listener redrawing on the announcement sees the new value rather than the old one.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Changed_IsRaisedAfterTheResultsAreSet()
+    {
+        CalculatorModel model = new()
+        {
+            Mode = WaterInputMode.Conductivity,
+            WaterPresetId = "CalciumBicarbonateHard",
+        };
+        model.SeedReadingFromPreset();
+
+        double seen = -1;
+        model.Changed += () => seen = model.Alkalinity;
+
+        model.Recalculate();
+
+        seen.Should().BeGreaterThan(0).And.Be(model.Alkalinity);
+    }
+}

--- a/web/SYT.NPKTools.Calculator/CalculatorModel.cs
+++ b/web/SYT.NPKTools.Calculator/CalculatorModel.cs
@@ -333,10 +333,44 @@ public sealed class CalculatorModel
     public bool HasRun { get; private set; }
 
     /// <summary>
-    /// Runs the whole chain. Never throws for bad input — a malformed target lands in
-    /// <see cref="Error"/>, because a calculator that crashes on a typo is unusable.
+    /// Raised after every <see cref="Recalculate"/>, so a panel that shows a result can redraw.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Necessary, not decorative. Blazor skips re-rendering a child component whose parameters have not
+    /// changed, and these panels take one parameter — an <see cref="EventCallback"/> to the same method
+    /// on the same page, which compares equal on every pass. So a panel only ever redrew when it
+    /// handled the event itself: editing the water updated the water card and left the acidification
+    /// card showing what it had computed at startup, which for a page that opens on osmosis meant
+    /// nothing at all.
+    /// </para>
+    /// <para>
+    /// The page cannot fix this from its side — it re-renders, and the children are skipped anyway. So
+    /// the model says when it has changed and each panel listens, the same arrangement the language
+    /// picker already uses.
+    /// </para>
+    /// </remarks>
+    public event Action? Changed;
+
+    /// <summary>
+    /// Runs the whole chain, then announces it. Never throws for bad input — a malformed target lands
+    /// in <see cref="Error"/>, because a calculator that crashes on a typo is unusable.
     /// </summary>
     public void Recalculate()
+    {
+        try
+        {
+            Run();
+        }
+        finally
+        {
+            // In a finally because a stale screen is worse than a lost calculation: if Run ever does
+            // throw, the panels should still be told to redraw from whatever state it left behind.
+            Changed?.Invoke();
+        }
+    }
+
+    private void Run()
     {
         HasRun = true;
         Error = null;

--- a/web/SYT.NPKTools.Calculator/Components/AcidPanel.razor
+++ b/web/SYT.NPKTools.Calculator/Components/AcidPanel.razor
@@ -1,4 +1,5 @@
 @inject CalculatorModel Model
+@implements IDisposable
 
 @*
     Only shown when there is alkalinity to neutralise, because on reverse osmosis there is nothing to
@@ -89,6 +90,15 @@
 }
 
 @code {
+    // Blazor skips a child whose parameters have not changed, and this panel's only parameter is a
+    // callback that never does — so without this it would keep showing what it drew at startup. See
+    // CalculatorModel.Changed.
+    protected override void OnInitialized() => Model.Changed += Redraw;
+
+    private void Redraw() => InvokeAsync(StateHasChanged);
+
+    public void Dispose() => Model.Changed -= Redraw;
+
     /// <summary>Raised after any edit, so the page can recalculate and persist.</summary>
     [Parameter]
     public EventCallback Changed { get; set; }

--- a/web/SYT.NPKTools.Calculator/Components/SaltPicker.razor
+++ b/web/SYT.NPKTools.Calculator/Components/SaltPicker.razor
@@ -1,5 +1,6 @@
 @inject CalculatorModel Model
 @inject Translations T
+@implements IDisposable
 
 @*
     The shelf. Lifted out of Home.razor because a list plus an entry form is more than a page should
@@ -59,6 +60,15 @@
 </section>
 
 @code {
+    // Blazor skips a child whose parameters have not changed, and this panel's only parameter is a
+    // callback that never does — so without this it would keep showing what it drew at startup. See
+    // CalculatorModel.Changed.
+    protected override void OnInitialized() => Model.Changed += Redraw;
+
+    private void Redraw() => InvokeAsync(StateHasChanged);
+
+    public void Dispose() => Model.Changed -= Redraw;
+
     /// <summary>Raised after any edit, so the page can recalculate and persist.</summary>
     [Parameter]
     public EventCallback Changed { get; set; }

--- a/web/SYT.NPKTools.Calculator/Components/StoragePanel.razor
+++ b/web/SYT.NPKTools.Calculator/Components/StoragePanel.razor
@@ -62,6 +62,11 @@
 </section>
 
 @code {
+    // The download link's href is built from the current setup at render time, so this panel has to be
+    // redrawn when the setup changes — otherwise the file offered is the one from startup. Blazor skips
+    // a child whose parameters have not changed; see CalculatorModel.Changed.
+    private void Redraw() => InvokeAsync(StateHasChanged);
+
     private IJSObjectReference? _module;
     private bool _writing;
     private bool _copied;
@@ -72,6 +77,8 @@
     /// <summary>Raised after loading a file or a link, so the page can re-render the results.</summary>
     [Parameter]
     public EventCallback Changed { get; set; }
+
+    protected override void OnInitialized() => Model.Changed += Redraw;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -242,6 +249,7 @@
     public async ValueTask DisposeAsync()
     {
         Navigation.LocationChanged -= OnLocationChanged;
+        Model.Changed -= Redraw;
 
         if (_module is not null)
         {

--- a/web/SYT.NPKTools.Calculator/Components/WaterPanel.razor
+++ b/web/SYT.NPKTools.Calculator/Components/WaterPanel.razor
@@ -1,5 +1,6 @@
 @inject CalculatorModel Model
 @inject Translations T
+@implements IDisposable
 
 @*
     Everything about the source water: how it is described, and what that description implies. Lifted
@@ -162,6 +163,15 @@
 </section>
 
 @code {
+    // Blazor skips a child whose parameters have not changed, and this panel's only parameter is a
+    // callback that never does — so without this it would keep showing what it drew at startup. See
+    // CalculatorModel.Changed.
+    protected override void OnInitialized() => Model.Changed += Redraw;
+
+    private void Redraw() => InvokeAsync(StateHasChanged);
+
+    public void Dispose() => Model.Changed -= Redraw;
+
     /// <summary>Raised after any edit, so the page can recalculate and persist.</summary>
     [Parameter]
     public EventCallback Changed { get; set; }


### PR DESCRIPTION
Found while localising `AcidPanel`: I could not make the card appear in a browser in order to check its text, in any water mode, on `main`.

## What happens

Blazor does not re-render a child component whose parameters have not changed. Every panel on this page takes exactly one parameter — `Changed="Edited"`, an `EventCallback` to the same method on the same page, equal on every pass. So a panel redraws **only when it handles the event itself**.

`AcidPanel` renders when `Model.Alkalinity > 0`. The page opens on osmosis, where alkalinity is zero, so its first pass renders nothing — and nothing ever asks it again. The acid dose, the overshoot warning that names a better acid, and the note about an open reservoir losing CO₂ have all been unreachable.

## How it was established

Not by reasoning about Blazor. A probe was added to `WaterPanel` and `AcidPanel` at once, each printing `Model.GetHashCode()`, the alkalinity it could see, and a render counter:

```
after ec click
   water: probe alk=2.723 id=898124686 renders=3
   acid : probe alk=0.000 id=898124686 renders=1
```

Same instance — so not a service-lifetime mistake — and the acid card had rendered exactly once, still holding the startup value while the card directly above it held the new one. Editing a field the page itself owns did not change it either: the page re-renders, its children are skipped anyway.

## The fix

`CalculatorModel` raises `Changed` after every `Recalculate`, in a `finally` so a failed calculation still triggers the redraw, and the four panels subscribe — the same arrangement `Translations.Changed` already uses for the language picker.

This also fixes a second stale reading nobody had noticed: `StoragePanel` builds the download link's `href` from the setup at render time, so the file it offered was the setup as it stood when the page opened.

## Evidence

From a clean slate — `localStorage` cleared, no fragment — switching to EC and back:

| | `main` | this branch |
|---|---|---|
| fresh (osmosis) | no card, href 2881 | no card, href 2881 |
| after EC | **no card**, href 2881 | card, href 2889 |
| back to osmosis | no card, href 2881 | no card, href 2884 |

805 tests pass. Three new ones cover the announcement itself, including that it fires when the calculation fails and that the results are already set when it does; that the panels listen is markup, and shows up in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam