### PR TITLE
The concentrate warnings, written rather than passed through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   collapsed, and is still what links and files carry — so a typo in it no longer destroys the target.
 - Links carry the water and acid settings. Existing links keep working.
 
+- `ConcentrateWarning` carries the two figures behind its message — `Actual` and `Allowed`: the grams
+  per litre a salt needs against the grams per litre that dissolve, or how far past full a tank is.
+  `Message` is unchanged. Both are optional parameters at the end of the record, so existing source
+  keeps compiling; a caller recompiling against a new build is the intended path.
 - **Breaking, `SYT.NPKTools`.** `ChemicalFormula.TryParse` and `FormulaComposition.TryCreate` report a
   `FormulaProblem` rather than a `string`: which failure it is, the offending character or symbol, and
   where it is. The English prose is still there as `FormulaProblem.Message`, for a developer reading a

--- a/docs/superpowers/plans/2026-08-03-localisation-machinery.md
+++ b/docs/superpowers/plans/2026-08-03-localisation-machinery.md
@@ -890,9 +890,9 @@ Task 4 is being landed one component per pull request, because the check that ma
 | `Components/AcidPanel.razor`, `Pages/NotFound.razor` | #29 | done |
 | `Components/StoragePanel.razor` | #30 | done |
 | `Components/CustomSaltForm.razor` | #31, #33 | done, notices included |
-| `Components/RecipeCard.razor` | #32 | done, apart from `warning.Message` |
+| `Components/RecipeCard.razor` | #32, #34 | done |
 | Formula and salt failures → named reasons | #33 | done |
-| The two concentrate warning messages | — | to do, same shape — see below |
+| The two concentrate warning messages | #34 | done — all four kinds |
 
 **Capture the rendered text with `innerText`, per component, in every state the component has.** Three
 capture methods were tried and only the third is honest: a text-node walk invents a space where two

--- a/src/SYT.NPKTools/Concentrates/ConcentrateExtensions.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateExtensions.cs
@@ -118,7 +118,9 @@ public static class ConcentrateExtensions
                     [c.Fertilizer.Name.Value],
                     $"Tank {tank.Tank} needs {c.GramsPerLiter:F1} g/L of '{c.Fertilizer.Name.Value}', "
                         + $"which dissolves to {c.SolubilityLimit:F0} g/L at 20 °C. Use a larger "
-                        + "concentrate volume, or a more soluble source of that element.")));
+                        + "concentrate volume, or a more soluble source of that element.",
+                    c.GramsPerLiter,
+                    c.SolubilityLimit)));
 
             if (tank.IsSaturated)
             {
@@ -128,7 +130,9 @@ public static class ConcentrateExtensions
                     [.. tank.Components.Select(c => c.Fertilizer.Name.Value)],
                     $"Tank {tank.Tank} is at {tank.SaturationFraction:P0} of saturation: its salts "
                         + "together need more water than the tank holds, because they compete for the "
-                        + "same water. Use a larger concentrate volume."));
+                        + "same water. Use a larger concentrate volume.",
+                    tank.SaturationFraction,
+                    1));
             }
 
             maxRatio = Smaller(maxRatio, CeilingFor(tank, solution.WaterLiters));

--- a/src/SYT.NPKTools/Concentrates/ConcentrateWarning.cs
+++ b/src/SYT.NPKTools/Concentrates/ConcentrateWarning.cs
@@ -44,9 +44,26 @@ public enum ConcentrateWarningKind
 /// <param name="Kind">What sort of problem this is.</param>
 /// <param name="Tank">The tank it concerns.</param>
 /// <param name="Fertilizers">The fertilizers involved, so a caller can point at them.</param>
-/// <param name="Message">A description suitable for showing to a person.</param>
+/// <param name="Message">English prose, for a developer reading a log.</param>
+/// <param name="Actual">
+/// The figure that is wrong, for the kinds that have one: grams per litre needed for
+/// <see cref="ConcentrateWarningKind.SolubilityExceeded"/>, the fraction of saturation for
+/// <see cref="ConcentrateWarningKind.TankSaturated"/>. Null for the kinds that carry no number.
+/// </param>
+/// <param name="Allowed">
+/// What that figure may be — grams per litre that dissolve, or 1 for a full tank. Null when
+/// <paramref name="Actual"/> is.
+/// </param>
+/// <remarks>
+/// <see cref="Message"/> is prose and cannot be translated by whoever shows it. The kind, the tank, the
+/// fertilizers and the two figures are the same information as data, so an application can write the
+/// sentence in the language of the person reading it — which for these warnings is somebody deciding
+/// whether their concentrate will physically dissolve.
+/// </remarks>
 public sealed record ConcentrateWarning(
     ConcentrateWarningKind Kind,
     ConcentrateType Tank,
     IReadOnlyList<string> Fertilizers,
-    string Message);
+    string Message,
+    double? Actual = null,
+    double? Allowed = null);

--- a/tests/SYT.NPKTools.Tests/ConcentrateTests.cs
+++ b/tests/SYT.NPKTools.Tests/ConcentrateTests.cs
@@ -355,6 +355,67 @@ public class ConcentrateTests
     }
 
     /// <summary>
+    /// A warning about solubility carries the two figures its sentence needs, not only a sentence.
+    /// </summary>
+    /// <remarks>
+    /// The prose stays for logs. An application showing this to somebody deciding whether their
+    /// concentrate will dissolve has to write the sentence in their language, and cannot do that from
+    /// prose — so the grams per litre needed and the grams per litre that dissolve are on the record.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_WhenASaltCannotDissolve_CarriesTheFigures()
+    {
+        // Calcium monobasic phosphate dissolves to 18 g/L, the lowest figure in the table, so a
+        // modest weight in a modest volume is over it several times.
+        Fertilizer phosphate = new FertilizerBuilder()
+            .AddName("Calcium Monobasic Phosphate")
+            .AddType(ConcentrateType.B)
+            .AddP(23.5).AddCaNonChelated(15.9)
+            .AddWeight(20)
+            .Build();
+        Solution solution = new([phosphate], waterLiters: 100);
+
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 0.5);
+
+        ConcentrateWarning warning = plan.Warnings
+            .Should().ContainSingle(w => w.Kind == ConcentrateWarningKind.SolubilityExceeded).Subject;
+        warning.Actual.Should().BeApproximately(40, Precision);
+        warning.Allowed.Should().Be(18);
+    }
+
+    /// <summary>
+    /// A saturated tank carries the fraction it is saturated to, and what a full tank would be.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AsConcentrate_WhenATankIsSaturated_CarriesTheFraction()
+    {
+        // Both named as the solubility table names them, so both have a figure and the tank can be
+        // judged saturated at all: 111 g/L for the sulfate, 226 for the phosphate.
+        Fertilizer sulfate = new FertilizerBuilder()
+            .AddName("Potassium Sulfate (SOP)")
+            .AddType(ConcentrateType.B)
+            .AddK(44.87).AddS(18.4)
+            .AddWeight(40)
+            .Build();
+        Fertilizer phosphate = new FertilizerBuilder()
+            .AddName("Potassium Dihydrogen Phosphate (MKP)")
+            .AddType(ConcentrateType.B)
+            .AddP(22.76).AddK(28.73)
+            .AddWeight(40)
+            .Build();
+        Solution solution = new([sulfate, phosphate], waterLiters: 100);
+
+        ConcentratePlan plan = solution.AsConcentrate(concentrateLiters: 0.5);
+
+        ConcentrateWarning warning = plan.Warnings
+            .Should().ContainSingle(w => w.Kind == ConcentrateWarningKind.TankSaturated).Subject;
+        warning.Actual.Should().BeGreaterThan(1);
+        warning.Allowed.Should().Be(1);
+    }
+
+    /// <summary>
     /// Guards the extension against a null receiver, which a caller can reach through an explicit
     /// static invocation.
     /// </summary>

--- a/web/SYT.NPKTools.Calculator/Components/RecipeCard.razor
+++ b/web/SYT.NPKTools.Calculator/Components/RecipeCard.razor
@@ -171,7 +171,7 @@
                 <div class="notice @(warning.Kind == ConcentrateWarningKind.TankInferred ? "info" : "error")"
                      role="@(warning.Kind == ConcentrateWarningKind.TankInferred ? "status" : "alert")">
                     <Icon Kind="@(warning.Kind == ConcentrateWarningKind.TankInferred ? IconKind.Info : IconKind.Error)" />
-                    <span><strong>@T[$"concentrate.warn.{warning.Kind}"].</strong> @warning.Message</span>
+                    <span><strong>@T[$"concentrate.warn.{warning.Kind}"].</strong> @Explain(T, warning)</span>
                 </div>
             }
         </details>
@@ -234,6 +234,35 @@
         yield return ("N:S", r.NitrogenToSulfur);
         yield return ("N:P", r.NitrogenToPhosphorus);
     }
+
+    // The library describes these in prose written for a developer; the numbers behind the prose are on
+    // the record, so the sentence is written here instead. ConcentrateWarning.Message stays for logs.
+    private static string Explain(Translations t, ConcentrateWarning warning) => warning.Kind switch
+    {
+        ConcentrateWarningKind.SolubilityExceeded => t.Format(
+            "concentrate.warn.SolubilityExceeded.detail",
+            warning.Tank.ToString(),
+            warning.Actual?.ToString("F1") ?? "?",
+            warning.Fertilizers.Count > 0 ? warning.Fertilizers[0] : "?",
+            warning.Allowed?.ToString("F0") ?? "?"),
+
+        ConcentrateWarningKind.TankSaturated => t.Format(
+            "concentrate.warn.TankSaturated.detail",
+            warning.Tank.ToString(),
+            warning.Actual?.ToString("P0") ?? "?"),
+
+        // Both groups of salts in one list. The library keeps them apart because it knows which is
+        // which; a grower is being told to move one group, and the names are what they act on.
+        ConcentrateWarningKind.PrecipitationRisk => t.Format(
+            "concentrate.warn.PrecipitationRisk.detail",
+            warning.Tank.ToString(),
+            string.Join(", ", warning.Fertilizers)),
+
+        _ => t.Format(
+            "concentrate.warn.TankInferred.detail",
+            warning.Fertilizers.Count > 0 ? warning.Fertilizers[0] : "?",
+            warning.Tank.ToString()),
+    };
 
     // One key per whole line rather than a stem plus an ending: "saturation unknown" is not a
     // sentence a translator can append to a phrase that ends in a unit.

--- a/web/SYT.NPKTools.Calculator/Resources/de.json
+++ b/web/SYT.NPKTools.Calculator/Resources/de.json
@@ -155,6 +155,10 @@
   "concentrate.warn.SolubilityExceeded": "Will not dissolve",
   "concentrate.warn.TankSaturated": "Tank saturated",
   "concentrate.warn.TankInferred": "Tank inferred",
+  "concentrate.warn.SolubilityExceeded.detail": "Tank {0} needs {1} g/L of '{2}', which dissolves to {3} g/L at 20 °C. Use a larger concentrate volume, or a more soluble source of that element.",
+  "concentrate.warn.TankSaturated.detail": "Tank {0} is at {1} of saturation: its salts together need more water than the tank holds, because they compete for the same water. Use a larger concentrate volume.",
+  "concentrate.warn.PrecipitationRisk.detail": "Tank {0} holds calcium together with sulfate or phosphate ({1}). These precipitate at concentrate strength even though they stay dissolved at working strength. Move one group to the other tank.",
+  "concentrate.warn.TankInferred.detail": "'{0}' has no tank of its own, so tank {1} was chosen from what it contains.",
   "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
   "recipes.empty.none": "No recipe for this combination. See the message on the left.",
   "recipes.title": {

--- a/web/SYT.NPKTools.Calculator/Resources/en.json
+++ b/web/SYT.NPKTools.Calculator/Resources/en.json
@@ -155,6 +155,10 @@
   "concentrate.warn.SolubilityExceeded": "Will not dissolve",
   "concentrate.warn.TankSaturated": "Tank saturated",
   "concentrate.warn.TankInferred": "Tank inferred",
+  "concentrate.warn.SolubilityExceeded.detail": "Tank {0} needs {1} g/L of '{2}', which dissolves to {3} g/L at 20 °C. Use a larger concentrate volume, or a more soluble source of that element.",
+  "concentrate.warn.TankSaturated.detail": "Tank {0} is at {1} of saturation: its salts together need more water than the tank holds, because they compete for the same water. Use a larger concentrate volume.",
+  "concentrate.warn.PrecipitationRisk.detail": "Tank {0} holds calcium together with sulfate or phosphate ({1}). These precipitate at concentrate strength even though they stay dissolved at working strength. Move one group to the other tank.",
+  "concentrate.warn.TankInferred.detail": "'{0}' has no tank of its own, so tank {1} was chosen from what it contains.",
   "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
   "recipes.empty.none": "No recipe for this combination. See the message on the left.",
   "recipes.title": {

--- a/web/SYT.NPKTools.Calculator/Resources/es.json
+++ b/web/SYT.NPKTools.Calculator/Resources/es.json
@@ -155,6 +155,10 @@
   "concentrate.warn.SolubilityExceeded": "Will not dissolve",
   "concentrate.warn.TankSaturated": "Tank saturated",
   "concentrate.warn.TankInferred": "Tank inferred",
+  "concentrate.warn.SolubilityExceeded.detail": "Tank {0} needs {1} g/L of '{2}', which dissolves to {3} g/L at 20 °C. Use a larger concentrate volume, or a more soluble source of that element.",
+  "concentrate.warn.TankSaturated.detail": "Tank {0} is at {1} of saturation: its salts together need more water than the tank holds, because they compete for the same water. Use a larger concentrate volume.",
+  "concentrate.warn.PrecipitationRisk.detail": "Tank {0} holds calcium together with sulfate or phosphate ({1}). These precipitate at concentrate strength even though they stay dissolved at working strength. Move one group to the other tank.",
+  "concentrate.warn.TankInferred.detail": "'{0}' has no tank of its own, so tank {1} was chosen from what it contains.",
   "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
   "recipes.empty.none": "No recipe for this combination. See the message on the left.",
   "recipes.title": {

--- a/web/SYT.NPKTools.Calculator/Resources/nl.json
+++ b/web/SYT.NPKTools.Calculator/Resources/nl.json
@@ -155,6 +155,10 @@
   "concentrate.warn.SolubilityExceeded": "Will not dissolve",
   "concentrate.warn.TankSaturated": "Tank saturated",
   "concentrate.warn.TankInferred": "Tank inferred",
+  "concentrate.warn.SolubilityExceeded.detail": "Tank {0} needs {1} g/L of '{2}', which dissolves to {3} g/L at 20 °C. Use a larger concentrate volume, or a more soluble source of that element.",
+  "concentrate.warn.TankSaturated.detail": "Tank {0} is at {1} of saturation: its salts together need more water than the tank holds, because they compete for the same water. Use a larger concentrate volume.",
+  "concentrate.warn.PrecipitationRisk.detail": "Tank {0} holds calcium together with sulfate or phosphate ({1}). These precipitate at concentrate strength even though they stay dissolved at working strength. Move one group to the other tank.",
+  "concentrate.warn.TankInferred.detail": "'{0}' has no tank of its own, so tank {1} was chosen from what it contains.",
   "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
   "recipes.empty.none": "No recipe for this combination. See the message on the left.",
   "recipes.title": {

--- a/web/SYT.NPKTools.Calculator/Resources/pl.json
+++ b/web/SYT.NPKTools.Calculator/Resources/pl.json
@@ -155,6 +155,10 @@
   "concentrate.warn.SolubilityExceeded": "Will not dissolve",
   "concentrate.warn.TankSaturated": "Tank saturated",
   "concentrate.warn.TankInferred": "Tank inferred",
+  "concentrate.warn.SolubilityExceeded.detail": "Tank {0} needs {1} g/L of '{2}', which dissolves to {3} g/L at 20 °C. Use a larger concentrate volume, or a more soluble source of that element.",
+  "concentrate.warn.TankSaturated.detail": "Tank {0} is at {1} of saturation: its salts together need more water than the tank holds, because they compete for the same water. Use a larger concentrate volume.",
+  "concentrate.warn.PrecipitationRisk.detail": "Tank {0} holds calcium together with sulfate or phosphate ({1}). These precipitate at concentrate strength even though they stay dissolved at working strength. Move one group to the other tank.",
+  "concentrate.warn.TankInferred.detail": "'{0}' has no tank of its own, so tank {1} was chosen from what it contains.",
   "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
   "recipes.empty.none": "No recipe for this combination. See the message on the left.",
   "recipes.title": {

--- a/web/SYT.NPKTools.Calculator/Resources/ru.json
+++ b/web/SYT.NPKTools.Calculator/Resources/ru.json
@@ -155,6 +155,10 @@
   "concentrate.warn.SolubilityExceeded": "Will not dissolve",
   "concentrate.warn.TankSaturated": "Tank saturated",
   "concentrate.warn.TankInferred": "Tank inferred",
+  "concentrate.warn.SolubilityExceeded.detail": "Tank {0} needs {1} g/L of '{2}', which dissolves to {3} g/L at 20 °C. Use a larger concentrate volume, or a more soluble source of that element.",
+  "concentrate.warn.TankSaturated.detail": "Tank {0} is at {1} of saturation: its salts together need more water than the tank holds, because they compete for the same water. Use a larger concentrate volume.",
+  "concentrate.warn.PrecipitationRisk.detail": "Tank {0} holds calcium together with sulfate or phosphate ({1}). These precipitate at concentrate strength even though they stay dissolved at working strength. Move one group to the other tank.",
+  "concentrate.warn.TankInferred.detail": "'{0}' has no tank of its own, so tank {1} was chosen from what it contains.",
   "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
   "recipes.empty.none": "No recipe for this combination. See the message on the left.",
   "recipes.title": {

--- a/web/SYT.NPKTools.Calculator/Resources/tr.json
+++ b/web/SYT.NPKTools.Calculator/Resources/tr.json
@@ -155,6 +155,10 @@
   "concentrate.warn.SolubilityExceeded": "Will not dissolve",
   "concentrate.warn.TankSaturated": "Tank saturated",
   "concentrate.warn.TankInferred": "Tank inferred",
+  "concentrate.warn.SolubilityExceeded.detail": "Tank {0} needs {1} g/L of '{2}', which dissolves to {3} g/L at 20 °C. Use a larger concentrate volume, or a more soluble source of that element.",
+  "concentrate.warn.TankSaturated.detail": "Tank {0} is at {1} of saturation: its salts together need more water than the tank holds, because they compete for the same water. Use a larger concentrate volume.",
+  "concentrate.warn.PrecipitationRisk.detail": "Tank {0} holds calcium together with sulfate or phosphate ({1}). These precipitate at concentrate strength even though they stay dissolved at working strength. Move one group to the other tank.",
+  "concentrate.warn.TankInferred.detail": "'{0}' has no tank of its own, so tank {1} was chosen from what it contains.",
   "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
   "recipes.empty.none": "No recipe for this combination. See the message on the left.",
   "recipes.title": {

--- a/web/SYT.NPKTools.Calculator/Resources/uk.json
+++ b/web/SYT.NPKTools.Calculator/Resources/uk.json
@@ -155,6 +155,10 @@
   "concentrate.warn.SolubilityExceeded": "Will not dissolve",
   "concentrate.warn.TankSaturated": "Tank saturated",
   "concentrate.warn.TankInferred": "Tank inferred",
+  "concentrate.warn.SolubilityExceeded.detail": "Tank {0} needs {1} g/L of '{2}', which dissolves to {3} g/L at 20 °C. Use a larger concentrate volume, or a more soluble source of that element.",
+  "concentrate.warn.TankSaturated.detail": "Tank {0} is at {1} of saturation: its salts together need more water than the tank holds, because they compete for the same water. Use a larger concentrate volume.",
+  "concentrate.warn.PrecipitationRisk.detail": "Tank {0} holds calcium together with sulfate or phosphate ({1}). These precipitate at concentrate strength even though they stay dissolved at working strength. Move one group to the other tank.",
+  "concentrate.warn.TankInferred.detail": "'{0}' has no tank of its own, so tank {1} was chosen from what it contains.",
   "recipes.empty.noRun": "Enter a target and the calculator will work out the recipes.",
   "recipes.empty.none": "No recipe for this combination. See the message on the left.",
   "recipes.title": {


### PR DESCRIPTION
The last of the library's prose to reach the screen. With this, nothing the interface shows is English by accident.

`ConcentrateWarning` carried a `Message` with its numbers already formatted into it, so the app could not write the sentence itself. It now carries them as data too:

```csharp
double? Actual,   // g/L a salt needs, or how far past full a tank is
double? Allowed   // g/L that dissolve, or 1 for a full tank
```

`Message` is unchanged, for logs and for anyone using the library directly. Both are optional parameters at the end of the record, so existing source keeps compiling.

## Two sentences keep their wording, two change

**Unchanged**, because they were already written for a grower — "Use a larger concentrate volume" is advice somebody can act on:

> **Will not dissolve.** Tank B needs 40.0 g/L of 'Calcium Monobasic Phosphate', which dissolves to 18 g/L at 20 °C. …
> **Tank saturated.** Tank B is at 136 % of saturation: its salts together need more water than the tank holds …

**Changed**, and neither is reachable from this interface:

| | Was | Is |
|---|---|---|
| inferred tank | "…tank A was inferred from its composition. **Set ConcentrateType explicitly to be sure.**" | "'Urea' has no tank of its own, so tank A was chosen from what it contains." |
| precipitation risk | names the calcium salts and the sulfate/phosphate salts as two separate groups | names them in one list |

The first was an instruction to a programmer sitting in a grower's warning. The second is a real loss of precision: the record cannot express two groups, and what a grower acts on is the names, so they are in one list.

## Verification

The results column against a build of `main`, in the same five states as #32 — byte-identical, 52,311 characters. Both saturation warnings appear there with their figures, including the `%` spacing, so the two sentences that were meant to stay the same are confirmed to have stayed the same.

## One thing found and deliberately left alone

The library formats its own `Message` with the **current culture**, so on a machine with a comma decimal separator it reads `40,0 g/L`. Nothing on screen is affected — the app no longer shows `Message`, and it is built with `InvariantGlobalization=true` — but a test asserting on that text would fail in half of Europe. The two new tests assert on `Actual` and `Allowed` instead. Worth its own ticket if the library's own prose should be invariant; it is not this change.

820 tests pass.

## After this

Only the words are left: eight translations against `docs/superpowers/glossary-hydroponics.md`, a reviewer per language, and a layout pass — German and Russian run 20–35% longer than English, which the 2×2 / 4-across grids will feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam