### PR TITLE
Say why the two Blazor package versions differ

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,11 +22,15 @@
     The browser calculator under web/. Not shipped as a package — it is the reference application that
     demonstrates the library runs client-side.
 
-    Held at 10.0.0 rather than the newest patch, which is not laziness: Blazor 10.0.10 requires
-    Microsoft.Extensions.DependencyInjection.Abstractions >= 10.0.10, and transitive pinning would then
-    force that package up from the 10.0.0 declared above. That 10.0.0 is a deliberate floor for the
-    shipped DI add-on, so the app yields rather than the library's contract moving. Raise both together
-    if the app ever needs a newer Blazor.
+    The two versions differ on purpose. The runtime package is held at 10.0.0, which is not laziness:
+    Blazor 10.0.10 requires Microsoft.Extensions.DependencyInjection.Abstractions >= 10.0.10, and
+    transitive pinning would then force that package up from the 10.0.0 declared above. That 10.0.0 is a
+    deliberate floor for the shipped DI add-on, so the app yields rather than the library's contract
+    moving. Raising it alone fails restore with NU1109; raise both together if the app ever needs a
+    newer Blazor.
+
+    The dev server is free to follow the newest patch. It is a `dotnet run` host for local work, never
+    referenced by anything shipped, and it does not reach the library's dependency graph.
   -->
   <ItemGroup Label="Web">
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />


### PR DESCRIPTION
A comment, after #26. The dev server is now at 10.0.10 while the runtime package stays at 10.0.0, and the old comment explained the group as a whole being held back — so it now reads as though the two had drifted apart by accident.

They have not, and I checked rather than assumed: raising `Microsoft.AspNetCore.Components.WebAssembly` to 10.0.10 fails restore with **NU1109**, because Blazor 10.0.10 wants `Microsoft.Extensions.DependencyInjection.Abstractions >= 10.0.10` and that package is a deliberate 10.0.0 floor for the shipped DI add-on. The old comment predicted exactly that; the comment now says it has been tried.

The dev server is a `dotnet run` host for local work, never referenced by anything shipped, and it does not reach the library's dependency graph — so it is free to follow the newest patch.

Written down because the next reader sees one package at 10.0.0 beside another at 10.0.10 and tidies up the difference.

Restore is clean; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam