### PR TITLE
The oxide warning covers calcium and magnesium too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- The oxide warning covers calcium and magnesium, not only phosphorus and potassium. Checking the
+  terminology for the eight languages turned up that the convention is law rather than custom and that
+  it reaches further than P₂O₅ and K₂O: Spanish, Polish and Turkish labelling rules all declare calcium
+  and magnesium as CaO and MgO, Turkish adds Na₂O and SO₃, and Poland publishes the conversion factors
+  in the same table as phosphorus and potassium. Divide CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 — the
+  note now says so, because a warning about half of a trap reads as permission for the other half.
 - The acidification card now appears when the water has alkalinity to neutralise. It never did:
   Blazor does not re-render a child component whose parameters have not changed, and each panel takes
   one — a callback to the same method on the page, equal on every pass — so a panel redrew only when it

--- a/src/SYT.NPKTools/Fertilizers/ChemicalFormula.cs
+++ b/src/SYT.NPKTools/Fertilizers/ChemicalFormula.cs
@@ -11,8 +11,10 @@ namespace SYT.NPKTools.Fertilizers;
 /// <para>
 /// Exists so a grower can describe a fertilizer the catalogue does not carry by writing what is on
 /// the bag rather than working out percentages by hand. Deriving them from the formula is both less
-/// work and less error-prone: fertilizer labels quote phosphorus and potassium as their oxides,
-/// P₂O₅ and K₂O, and a figure copied straight off a label overstates phosphorus by a factor of 2.3.
+/// work and less error-prone: fertilizer labels quote nutrients as their oxides, and a figure copied
+/// straight off a label overstates phosphorus by a factor of 2.3. It is not only P₂O₅ and K₂O — Spanish,
+/// Polish and Turkish labelling rules all extend the convention to calcium and magnesium, so a bag may
+/// declare CaO and MgO, and Turkish labels add Na₂O and SO₃.
 /// </para>
 /// <para>
 /// Nitrogen is reported by group as well as in total, because the library treats nitrate, ammonium

--- a/web/SYT.NPKTools.Calculator/Resources/de.json
+++ b/web/SYT.NPKTools.Calculator/Resources/de.json
@@ -58,7 +58,7 @@
   "salt.form.molarMass": "M = {0} g/mol — {1}",
   "salt.form.chelate.lead": "This looks like a chelate.",
   "salt.form.chelate.body": "A chelating agent carries nitrogen that holds the metal rather than feeding the plant, and a formula cannot tell the two apart — entered this way the salt would offer nitrogen it does not have. Describe it by percentages instead, where the agent is named.",
-  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. A bag quoting P₂O₅ or K₂O needs converting first: divide by 2.29 for phosphorus, by 1.20 for potassium.",
+  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. Labels quote oxides, and not only for phosphorus and potassium: divide P₂O₅ by 2.29, K₂O by 1.20, CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 before entering them.",
   "salt.error.Empty": "The formula is empty.",
   "salt.error.StartsWithNumber": "A formula cannot start with a number.",
   "salt.error.NoElements": "The formula names no elements.",

--- a/web/SYT.NPKTools.Calculator/Resources/en.json
+++ b/web/SYT.NPKTools.Calculator/Resources/en.json
@@ -58,7 +58,7 @@
   "salt.form.molarMass": "M = {0} g/mol — {1}",
   "salt.form.chelate.lead": "This looks like a chelate.",
   "salt.form.chelate.body": "A chelating agent carries nitrogen that holds the metal rather than feeding the plant, and a formula cannot tell the two apart — entered this way the salt would offer nitrogen it does not have. Describe it by percentages instead, where the agent is named.",
-  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. A bag quoting P₂O₅ or K₂O needs converting first: divide by 2.29 for phosphorus, by 1.20 for potassium.",
+  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. Labels quote oxides, and not only for phosphorus and potassium: divide P₂O₅ by 2.29, K₂O by 1.20, CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 before entering them.",
   "salt.error.Empty": "The formula is empty.",
   "salt.error.StartsWithNumber": "A formula cannot start with a number.",
   "salt.error.NoElements": "The formula names no elements.",

--- a/web/SYT.NPKTools.Calculator/Resources/es.json
+++ b/web/SYT.NPKTools.Calculator/Resources/es.json
@@ -58,7 +58,7 @@
   "salt.form.molarMass": "M = {0} g/mol — {1}",
   "salt.form.chelate.lead": "This looks like a chelate.",
   "salt.form.chelate.body": "A chelating agent carries nitrogen that holds the metal rather than feeding the plant, and a formula cannot tell the two apart — entered this way the salt would offer nitrogen it does not have. Describe it by percentages instead, where the agent is named.",
-  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. A bag quoting P₂O₅ or K₂O needs converting first: divide by 2.29 for phosphorus, by 1.20 for potassium.",
+  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. Labels quote oxides, and not only for phosphorus and potassium: divide P₂O₅ by 2.29, K₂O by 1.20, CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 before entering them.",
   "salt.error.Empty": "The formula is empty.",
   "salt.error.StartsWithNumber": "A formula cannot start with a number.",
   "salt.error.NoElements": "The formula names no elements.",

--- a/web/SYT.NPKTools.Calculator/Resources/nl.json
+++ b/web/SYT.NPKTools.Calculator/Resources/nl.json
@@ -58,7 +58,7 @@
   "salt.form.molarMass": "M = {0} g/mol — {1}",
   "salt.form.chelate.lead": "This looks like a chelate.",
   "salt.form.chelate.body": "A chelating agent carries nitrogen that holds the metal rather than feeding the plant, and a formula cannot tell the two apart — entered this way the salt would offer nitrogen it does not have. Describe it by percentages instead, where the agent is named.",
-  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. A bag quoting P₂O₅ or K₂O needs converting first: divide by 2.29 for phosphorus, by 1.20 for potassium.",
+  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. Labels quote oxides, and not only for phosphorus and potassium: divide P₂O₅ by 2.29, K₂O by 1.20, CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 before entering them.",
   "salt.error.Empty": "The formula is empty.",
   "salt.error.StartsWithNumber": "A formula cannot start with a number.",
   "salt.error.NoElements": "The formula names no elements.",

--- a/web/SYT.NPKTools.Calculator/Resources/pl.json
+++ b/web/SYT.NPKTools.Calculator/Resources/pl.json
@@ -58,7 +58,7 @@
   "salt.form.molarMass": "M = {0} g/mol — {1}",
   "salt.form.chelate.lead": "This looks like a chelate.",
   "salt.form.chelate.body": "A chelating agent carries nitrogen that holds the metal rather than feeding the plant, and a formula cannot tell the two apart — entered this way the salt would offer nitrogen it does not have. Describe it by percentages instead, where the agent is named.",
-  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. A bag quoting P₂O₅ or K₂O needs converting first: divide by 2.29 for phosphorus, by 1.20 for potassium.",
+  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. Labels quote oxides, and not only for phosphorus and potassium: divide P₂O₅ by 2.29, K₂O by 1.20, CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 before entering them.",
   "salt.error.Empty": "The formula is empty.",
   "salt.error.StartsWithNumber": "A formula cannot start with a number.",
   "salt.error.NoElements": "The formula names no elements.",

--- a/web/SYT.NPKTools.Calculator/Resources/ru.json
+++ b/web/SYT.NPKTools.Calculator/Resources/ru.json
@@ -58,7 +58,7 @@
   "salt.form.molarMass": "M = {0} g/mol — {1}",
   "salt.form.chelate.lead": "This looks like a chelate.",
   "salt.form.chelate.body": "A chelating agent carries nitrogen that holds the metal rather than feeding the plant, and a formula cannot tell the two apart — entered this way the salt would offer nitrogen it does not have. Describe it by percentages instead, where the agent is named.",
-  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. A bag quoting P₂O₅ or K₂O needs converting first: divide by 2.29 for phosphorus, by 1.20 for potassium.",
+  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. Labels quote oxides, and not only for phosphorus and potassium: divide P₂O₅ by 2.29, K₂O by 1.20, CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 before entering them.",
   "salt.error.Empty": "The formula is empty.",
   "salt.error.StartsWithNumber": "A formula cannot start with a number.",
   "salt.error.NoElements": "The formula names no elements.",

--- a/web/SYT.NPKTools.Calculator/Resources/tr.json
+++ b/web/SYT.NPKTools.Calculator/Resources/tr.json
@@ -58,7 +58,7 @@
   "salt.form.molarMass": "M = {0} g/mol — {1}",
   "salt.form.chelate.lead": "This looks like a chelate.",
   "salt.form.chelate.body": "A chelating agent carries nitrogen that holds the metal rather than feeding the plant, and a formula cannot tell the two apart — entered this way the salt would offer nitrogen it does not have. Describe it by percentages instead, where the agent is named.",
-  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. A bag quoting P₂O₅ or K₂O needs converting first: divide by 2.29 for phosphorus, by 1.20 for potassium.",
+  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. Labels quote oxides, and not only for phosphorus and potassium: divide P₂O₅ by 2.29, K₂O by 1.20, CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 before entering them.",
   "salt.error.Empty": "The formula is empty.",
   "salt.error.StartsWithNumber": "A formula cannot start with a number.",
   "salt.error.NoElements": "The formula names no elements.",

--- a/web/SYT.NPKTools.Calculator/Resources/uk.json
+++ b/web/SYT.NPKTools.Calculator/Resources/uk.json
@@ -58,7 +58,7 @@
   "salt.form.molarMass": "M = {0} g/mol — {1}",
   "salt.form.chelate.lead": "This looks like a chelate.",
   "salt.form.chelate.body": "A chelating agent carries nitrogen that holds the metal rather than feeding the plant, and a formula cannot tell the two apart — entered this way the salt would offer nitrogen it does not have. Describe it by percentages instead, where the agent is named.",
-  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. A bag quoting P₂O₅ or K₂O needs converting first: divide by 2.29 for phosphorus, by 1.20 for potassium.",
+  "salt.form.percentages.note": "Percentages by weight, as on the label — but as elements, not oxides. Labels quote oxides, and not only for phosphorus and potassium: divide P₂O₅ by 2.29, K₂O by 1.20, CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 before entering them.",
   "salt.error.Empty": "The formula is empty.",
   "salt.error.StartsWithNumber": "A formula cannot start with a number.",
   "salt.error.NoElements": "The formula names no elements.",


### PR DESCRIPTION
The note under the percentages tab warned about P₂O₅ and K₂O and stopped there. A warning about half of a trap reads as permission for the other half.

Checking terminology for the eight languages turned this up: the oxide convention is **law rather than custom**, and it reaches further than phosphorus and potassium.

- EU 2019/1009, Polish text: `wapń (Ca) = tlenek wapnia (CaO) × 0,715; magnez (Mg) = tlenek magnezu (MgO) × 0,603; sód (Na) = tlenek sodu (Na₂O) × 0,742; siarka (S) = tritlenek siarki (SO₃) × 0,400`
- Spanish RD 824/2005: *"con la excepción del calcio (CaO) y el magnesio (MgO), en que se utilizan igualmente los óxidos"*
- Turkish regulation annex: `Kalsiyum, suda çözünür CaO olarak ifade edilir`, plus Na₂O and SO₃ in the tolerances table
- Instytut Ogrodnictwa publishes the factors for CaO and MgO in the same conversion table as P and K

So a grower in Almería, Skierniewice or Antalya reads a calcium nitrate bag that says CaO, follows a note that mentions only phosphorus and potassium, and enters a figure 40% too high.

## The note now

> Percentages by weight, as on the label — but as elements, not oxides. Labels quote oxides, and not only for phosphorus and potassium: divide P₂O₅ by 2.29, K₂O by 1.20, CaO by 1.40, MgO by 1.66 and SO₃ by 2.5 before entering them.

Factors derived from atomic masses rather than copied: CaO is 71.47% calcium (÷1.3992), MgO 60.30% (÷1.6583), SO₃ 40.05% (÷2.497). All three agree with the regulation's own multipliers.

**Sodium is left out on purpose.** Na₂O appears only on Turkish labels, and sodium is a counter-ion nobody doses deliberately — five divisions in one note is already at the limit of what somebody will read before going back to their scale.

The library's remark on why deriving percentages from a formula beats copying them off a bag told the same half-truth, and is corrected.

## Verification

The custom salt form captured in all thirteen of its states against a build of `main`: the only difference is the note. 820 tests pass.

## Not done, and why

The ×640 ppm-meter factor that Turkish irrigation literature uses — you said 500 and 700 are fine, so the selector is unchanged.

The per-market hardness unit — Polish drop-test kits write German degrees as `°n`, Spanish reports use French degrees while the kits sold there print °dH, Flanders differs from the Netherlands. This needs no code: `water.gh` and `water.kh` are keys, so each language's file carries the unit its market prints. It is recorded in the glossary so the translations get it right rather than translating "°dH" literally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam