### PR TITLE
Let a concentrate tank's caption wrap

### DIFF
--- a/web/SYT.NPKTools.Calculator/Components/RecipeCard.razor
+++ b/web/SYT.NPKTools.Calculator/Components/RecipeCard.razor
@@ -130,7 +130,7 @@
                 @foreach (ConcentrateTank tank in plan.Tanks.Where(t => !t.IsEmpty))
                 {
                     <div class="col-4" style="grid-column:span 6">
-                        <div class="metric">
+                        <div class="metric tank">
                             <div class="label">
                                 @Describe(T, tank)
                             </div>

--- a/web/SYT.NPKTools.Calculator/wwwroot/css/app.css
+++ b/web/SYT.NPKTools.Calculator/wwwroot/css/app.css
@@ -427,6 +427,13 @@ tfoot td:first-child { text-align: left; font-family: var(--font-ui); }
 
 .metric .label { font-size: var(--text-xs); color: var(--text-muted); white-space: nowrap; }
 
+/*
+  A concentrate tank's caption is a line of prose — "Tank A — 118 g/L, 14 % saturated" — not a caption
+  like the ones beside it, and at phone widths it was 175px of text in a 133px box, spilling out of the
+  card. Nowrap earns its place on the short ones; here it has to give way.
+*/
+.metric.tank .label { white-space: normal; }
+
 .metric .value {
   font-family: var(--font-data);
   font-size: var(--text-lg);


### PR DESCRIPTION
Found by measuring, not by looking. A harness that walks every label at ten widths from 360 to 1440 in all eight languages reported the same failure 24 times:

```
.metric .label :: "Tank A — 118 g/L, 14 % saturated" 175>133
```

175px of text in a 133px box at 360px, spilling out of the card instead of wrapping.

`.metric .label` is `white-space: nowrap`, which is right for the captions beside it — "Water EC" and "Alkalinity" read better on one line. The tank line is not a caption; it is a sentence with two numbers in it. It gets a class of its own and `white-space: normal`.

**Every language failed identically**, because the string is mostly digits and units. So this was not a translation problem waiting to happen — it was already broken in English on a phone, and the audit for the translations is what surfaced it.

Harness clean afterwards: ten widths, eight languages, no label wider than its box and no page scrolling sideways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam