### PR TITLE
A contributing guide about this project, and the harnesses it names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,161 @@
-# How to Contribute to NPKTools
-## We welcome contributions from everyone who is willing to work collaboratively and contribute positively to the project. Whether you're fixing bugs, adding new features, improving documentation, or sharing your valuable feedback, here's how you can contribute:
+# Contributing to SYT.NPKTools
 
-### Get Familiar with the Project
+This is a fertilizer calculator. Somebody weighs out what it says and puts it in a tank that a crop
+depends on for months. That is the whole reason the conventions below are strict: a plausible-looking
+number is worse here than an error message, because an error message gets read.
 
-Understand the project's purpose and goals. Familiarize yourself with the project by reading the documentation, using the tool or software, and browsing the issues or discussions.
-Review the documentation. Make sure to read the existing README.md, CONTRIBUTING.md, and any other relevant documents in the repository.
+The repository is `i7aket/NPKTools`; the packages are `SYT.NPKTools` and
+`SYT.NPKTools.DependencyInjection`. Older documents and issues call it *NPKOptimizer* — that name is
+from 1.x and is only kept in [the migration section of the README](README.md#migrating-from-npktools-1x).
 
-### Communicate
+## What you need
 
-Join the community. Discuss your ideas. Before starting work on a significant change, open an issue or join existing discussions to propose your ideas and gather feedback.
+- **.NET 10 SDK.** `global.json` pins `10.0.100` with `rollForward: latestFeature`, so a newer 10.x
+  feature band is fine and 9.x is not.
+- Nothing else. The library has no dependencies at all, which is deliberate — it is what lets it run in
+  a browser. Please keep it that way; a `PackageReference` in `src/SYT.NPKTools` needs a very good
+  argument.
 
-### Find Tasks to Work On
+The solution file is **`SYT.NPKTools.slnx`**, not a `.sln`. Bare commands find it:
 
-Check the issues. Look for open issues tagged with labels like good first issue or help wanted. These are usually good starting points for new contributors.
-Review the roadmap. It can provide insight into long-term goals and where help is most needed.
+```bash
+dotnet build                       # Debug
+dotnet test                        # about 820 tests, a couple of seconds after a warm build
+dotnet format                      # before every commit
+dotnet format --verify-no-changes  # what CI runs
+```
 
-### Set Up Your Development Environment
+## Three things that will fail your build
 
-Fork and clone the repository. Make a personal fork of the repository and clone it to your machine.
-Follow the setup instructions. Make sure you can build and run the project locally. This often involves installing necessary dependencies and understanding the build process.
-### Make Changes
+1. **Warnings are errors.** `TreatWarningsAsErrors` with `AnalysisLevel=latest-recommended`. An
+   analyzer suggestion you disagree with is a conversation, not a `#pragma`.
+2. **Public members in `src/` need XML documentation.** CS1591 is enforced there and switched off in
+   `.editorconfig` only for value objects and constants tables, where the undocumented members are
+   `Value` accessors and string constants whose value is their meaning. A new public type without
+   `<summary>` breaks the build.
+3. **Formatting is not a review topic.** CI runs `dotnet format --verify-no-changes` on Ubuntu. Run
+   `dotnet format` locally and the subject never comes up.
 
-Create a new branch. Always make your changes in a new branch, named appropriately based on the feature or fix you're working on.
-Follow coding standards. Stick to the coding and commit guidelines recommended by the project to maintain code quality and readability.
-Test your changes. Ensure that your changes do not break existing functionality and that any new features include appropriate tests if applicable.
+Code-style rules (IDExxxx) stay editor suggestions rather than build errors — `.editorconfig` documents
+the conventions without making a stray blank line fail CI.
 
-### Submit Your Contribution
+## Tests
 
-Open a pull request (PR). Once your changes are ready, submit a pull request to the original repository. Provide a clear description of the changes and any other details that might help reviewers.
-Respond to feedback. Be open to feedback and willing to make further adjustments based on suggestions from the project maintainers.
+xUnit, and **AwesomeAssertions** — not FluentAssertions. The using is `using AwesomeAssertions;` and the
+API is the one you expect. `AutoFixture` and `NSubstitute` are available. All of them come from
+`tests/Directory.Build.props`, so **do not add `PackageReference` lines to a test project**; a project
+gets the harness by being named `*Tests`.
 
-### Stay Engaged
+```csharp
+/// <summary>
+/// Says what this covers, and — where it is not obvious — why it is worth covering.
+/// </summary>
+[Fact]
+[Trait("Category", "Unit")]
+public void Method_Scenario_Expectation()
+{
+    // Arrange, Act, Assert. The comments are optional; the order is not.
+}
+```
 
-Keep your fork up to date. Regularly sync your fork with the main repository to keep up with ongoing changes.
-Continue contributing. Stay involved in the project by continuing to contribute and collaborate with others.
-Thank You for Your Contributions!
-We appreciate your efforts in improving NPKTools and look forward to your creative and thoughtful contributions.
+- `Method_Scenario_Expectation` naming. `CA1707` is suppressed in test projects for exactly this.
+- `[Trait("Category", "Unit")]` on everything, so a category can be filtered.
+- A test that documents *why* a case matters earns its place. `Select_ForPolish_TreatsTwentyOneAsMany`
+  is a better name than `Select_Works`, and the remark above it should say that 21 behaves like 1 in
+  Russian and not in Polish — otherwise the next person "simplifies" the rule and the test looks wrong.
+- Not everything under `tests/` is a test project: `SYT.NPKTools.OrToolsOracle` is shared support code
+  for the differential tests and the benchmarks, and is marked `IsTestProject=false` so `dotnet test`
+  does not try to run it.
+
+**A number that comes from the physical world needs a source.** The EC model is checked against
+certified KCl conductivity standards, the solubility figures against published handbook values, the
+atomic masses against IUPAC. If you add a figure you cannot source, say so in the XML documentation and
+keep it out of the warnings a grower acts on. Reporting a figure as unchecked is the practice here;
+assuming it is safe is not.
+
+## The browser app
+
+`web/SYT.NPKTools.Calculator` is Blazor WebAssembly, and two of its constraints are easy to break by
+accident.
+
+**`InvariantGlobalization=true`.** No ICU, no culture-aware formatting. This is not a size
+optimisation: a culture-aware parser can read `1,5` grams as `15`, which is a tenfold weighing error.
+Parsing is tolerant and explicit — `Localisation/Numbers.cs` accepts a comma as a decimal point — and
+display is always invariant with a dot. Do not introduce `CultureInfo`-aware formatting, resx or
+satellite assemblies.
+
+**Every user-visible string lives behind a key** in `Resources/*.json`, in eight languages. A test
+fails if the eight files do not carry identical key sets, so adding a string means adding it to all
+eight. Two rules make the difference between a translatable interface and one that only looks
+translated:
+
+- **One key per sentence, never per fragment.** Do not assemble a sentence around a value in markup.
+  Word order differs across these eight languages, and a sentence built from pieces cannot be fixed by
+  a translator. `Translations.Format(key, values)` exists for this.
+- **Counts go through `Translations.Plural`**, never string concatenation. Russian, Ukrainian and
+  Polish take three forms, and Polish disagrees with Russian about 21.
+
+Terminology comes from [`docs/superpowers/glossary-hydroponics.md`](docs/superpowers/glossary-hydroponics.md),
+which was checked term by term against extension services, fertilizer registration certificates and
+labelling law — and which also records what could **not** be verified. Do not translate a new string
+from English alone: check whether the glossary fixes the term, and add it there if it does not.
+
+## Two traps that have cost real time
+
+- **`dotnet publish -o <dir>` does not clean the directory.** Stale assemblies accumulate and you end up
+  debugging a build that is not the one you think it is. Remove the directory first.
+- **Blazor does not re-render a child component whose parameters have not changed.** Every panel in the
+  calculator takes one parameter — an `EventCallback` to the same method on the page — which compares
+  equal on every pass, so a panel only ever redrew when it handled the event itself. The acidification
+  card was invisible for several releases because of this. `CalculatorModel.Changed` and
+  `Translations.Changed` exist so a panel can learn that the calculation or the language moved. A new
+  component that displays either should subscribe to both.
+
+## Verifying a change to the interface
+
+"Nothing visible changed" is a claim that has to be measured, and reading the diff does not measure it.
+Razor drops literal whitespace between an expression and the block that follows it, which is how two
+sentences once ran together in a change whose diff looked obviously correct.
+
+```bash
+# 1. Build the branch and a build of main, and serve both
+rm -rf /tmp/after && dotnet publish web/SYT.NPKTools.Calculator -c Release -o /tmp/after
+python3 scripts/serve.py /tmp/after/wwwroot 8082 &
+
+# 2. Capture the rendered text from each and diff it
+node scripts/rendered-text.mjs http://127.0.0.1:8081/ before.txt
+node scripts/rendered-text.mjs http://127.0.0.1:8082/ after.txt
+diff before.txt after.txt
+
+# 3. For anything touching layout or wording, measure every label
+node scripts/layout-audit.mjs http://127.0.0.1:8082/
+```
+
+`scripts/README.md` has the Chrome command the harnesses need. Both capture with `innerText`, which is
+what the layout actually shows: a text-node walk invents a space where two nodes touch, and
+`textContent` keeps the insignificant whitespace a wrapped line of markup leaves inside a block
+element. Both of those report differences that are not on the screen.
+
+One warning about the layout audit, learned the hard way: **it reported "no overflow anywhere" while
+silently measuring English eight times**, because a language change did not redraw the page. If you
+audit across languages, check that the pages differ in length before believing the result.
+
+## Commits and pull requests
+
+- Branch from `main`: `feat/…`, `fix/…`, `docs/…`, `chore/…`.
+- Conventional-commit subjects — `feat(calculator): …`, `fix(optimizer): …`. The body is where the
+  reasoning goes, and it is worth writing: it is the only place a future reader learns *why*.
+- One squash commit per pull request into `main`.
+- Fill in the [pull request template](.github/pull_request_template.md). Its checklist is the contract,
+  not a formality.
+- `CHANGELOG.md` gets an entry for anything a user would notice. A breaking change to a public API says
+  so in the entry, because the packages are consumed.
+- CI runs the build and the tests on Ubuntu, Windows and macOS, plus CodeQL. All of it has to be green.
+
+## Reporting something rather than fixing it
+
+A good bug report here carries the target string, the salts that were ticked and the water — or, far
+better, **the link the app puts in the address bar**, which carries the whole setup. Paste that and the
+problem is reproducible exactly.
+
+Open an issue before starting anything large, so nobody writes the same thing twice.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,65 @@
+# scripts
+
+Three small harnesses for checking a change to the browser app. They exist because the two questions
+that matter about an interface change — *did the words move?* and *does anything overflow?* — cannot be
+answered by reading a diff, and both were answered wrongly at least once by trying.
+
+Nothing here is part of the build. They need Node 24 or newer (for the built-in `WebSocket`) and Python 3.
+
+## Start a Chrome that will talk to them
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-audit \
+  --headless=new --no-first-run --disable-gpu about:blank &
+```
+
+On Linux, `google-chrome` or `chromium` with the same flags. The `--user-data-dir` matters: without it
+Chrome may attach to your everyday profile and refuse the debugging port.
+
+One caution that cost an afternoon: **headless Chrome clamps `--window-size` to about 500 CSS pixels
+wide and crops the screenshot silently.** That is why these scripts set the viewport through
+`Emulation.setDeviceMetricsOverride` instead, and why a "fix" for a phone-width layout problem should
+never be trusted until the measured viewport width is printed.
+
+## `serve.py` — serve a published build like a static host
+
+```bash
+python3 scripts/serve.py /tmp/after/wwwroot 8082
+```
+
+Threaded, because the WebAssembly runtime pulls dozens of assemblies at once and the stock
+single-threaded handler serialises them into a very long wait. Unknown paths fall back to `index.html`,
+which is what the Pages `404.html` copy does for deep links. It also sets `application/wasm`, without
+which the runtime refuses to start.
+
+## `rendered-text.mjs` — what the page actually shows, as text
+
+```bash
+node scripts/rendered-text.mjs http://127.0.0.1:8081/ before.txt
+node scripts/rendered-text.mjs http://127.0.0.1:8082/ after.txt      # your branch
+diff before.txt after.txt
+```
+
+Clears `localStorage` and reloads before capturing, because the app remembers the last setup and the
+last language — two builds can only be compared from the same starting state. Takes an optional language
+tag as a third argument. Prints a warning if a translation key reached the
+screen, which is what happens when a resource file is missing one.
+
+Use it to prove that a refactor changed where words come from and not what they say. Every string that
+moved behind a translation key in this repository was checked this way, and the check caught a key
+rendering as itself, and Razor swallowing the space between two sentences.
+
+## `layout-audit.mjs` — every label at every width in every language
+
+```bash
+node scripts/layout-audit.mjs http://127.0.0.1:8082/
+```
+
+Walks ten widths from 360 to 1440 in all eight languages and reports only failures: text wider than its
+own box, and any page that scrolls sideways. Silence is the pass condition.
+
+**Read its silence carefully.** It once reported "no overflow anywhere" while measuring English eight
+times, because switching the language did not redraw the page. If you are auditing across languages,
+confirm the pages differ in length first — `rendered-text.mjs` per language will tell you in one line
+each. A harness that cannot fail is not a harness.

--- a/scripts/layout-audit.mjs
+++ b/scripts/layout-audit.mjs
@@ -1,0 +1,89 @@
+// Measures the layout in every language at every width that matters, and reports only failures: text
+// wider than the box it sits in, and any page that scrolls sideways. Silence is the pass condition.
+//
+// Usage:  node scripts/layout-audit.mjs <url>
+//
+// Read its silence carefully. This harness once reported "no overflow anywhere" while measuring English
+// eight times, because changing the language redrew the header and not the page. Confirm the languages
+// differ — scripts/rendered-text.mjs prints a character count per language — before believing a pass.
+//
+// Needs a Chrome listening for the DevTools protocol; see scripts/README.md.
+if (!process.argv[2]) {
+  console.error('usage: node scripts/layout-audit.mjs <url>');
+  process.exit(2);
+}
+
+const tabs = await (await fetch('http://127.0.0.1:9222/json')).json();
+const page = tabs.find(x => x.type === 'page');
+if (!page) {
+  console.error('no page tab on 127.0.0.1:9222 — see scripts/README.md');
+  process.exit(2);
+}
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise(r => (ws.onopen = r));
+let id = 0; const p = new Map();
+ws.onmessage = e => { const m = JSON.parse(e.data); if (p.has(m.id)) { p.get(m.id)(m.result); p.delete(m.id); } };
+const send = (m, params = {}) => new Promise(res => { const n = ++id; p.set(n, res); ws.send(JSON.stringify({ id: n, method: m, params })); });
+const ev = async x => {
+  const r = await send('Runtime.evaluate', { expression: x, returnByValue: true, awaitPromise: true });
+  if (r?.exceptionDetails) throw new Error(JSON.stringify(r.exceptionDetails).slice(0, 300));
+  return r.result?.value;
+};
+const wait = ms => new Promise(r => setTimeout(r, ms));
+
+const LANGS = ['en', 'ru', 'uk', 'nl', 'de', 'es', 'pl', 'tr'];
+const WIDTHS = [360, 390, 414, 480, 620, 768, 900, 1024, 1280, 1440];
+
+// A label overflows when its text is wider than its own box. scrollWidth beats clientWidth by more
+// than a rounding error only when something is actually clipped or pushing out.
+const measure = `(() => {
+  const bad = [];
+  const seen = new Set();
+  const kinds = ['.metric .label', '.metric .value', 'th', '.field label', '.segmented button',
+                 '.chip', '.group-divider', 'h2', '.button-row button', '.button-row a', 'option'];
+  for (const sel of kinds) {
+    for (const el of document.querySelectorAll(sel)) {
+      if (el.scrollWidth > el.clientWidth + 1 && el.clientWidth > 0) {
+        const text = el.textContent.replace(/\\s+/g, ' ').trim().slice(0, 40);
+        const key = sel + '|' + text;
+        if (!seen.has(key)) { seen.add(key); bad.push(sel + ' :: "' + text + '" ' + el.scrollWidth + '>' + el.clientWidth); }
+      }
+    }
+  }
+  const wide = document.documentElement.scrollWidth > window.innerWidth + 1
+    ? 'PAGE SCROLLS SIDEWAYS ' + document.documentElement.scrollWidth + '>' + window.innerWidth : null;
+  return JSON.stringify({ bad, wide });
+})()`;
+
+await send('Page.navigate', { url: process.argv[2] });
+for (let i = 0; i < 90; i++) { if (await ev(`document.querySelectorAll('.metrics').length > 0`)) break; await wait(500); }
+await wait(1500);
+
+let failures = 0;
+for (const lang of LANGS) {
+  const set = await ev(`(() => {
+    const s = document.querySelector('select.language');
+    if (!s) return 'no picker';
+    s.value = '${lang}';
+    s.dispatchEvent(new Event('change', { bubbles: true }));
+    return true;
+  })()`);
+  if (set !== true) { console.log(lang, '->', set); continue; }
+  await wait(900);
+
+  for (const w of WIDTHS) {
+    await send('Emulation.setDeviceMetricsOverride', { width: w, height: 1400, deviceScaleFactor: 1, mobile: w < 620 });
+    await wait(450);
+    const { bad, wide } = JSON.parse(await ev(measure));
+    if (wide || bad.length) {
+      failures++;
+      console.log(`\n${lang} @ ${w}px`);
+      if (wide) console.log('   ' + wide);
+      for (const b of bad.slice(0, 8)) console.log('   ' + b);
+      if (bad.length > 8) console.log(`   … and ${bad.length - 8} more`);
+    }
+  }
+  process.stdout.write(`${lang} done  `);
+}
+console.log(`\n\n${failures ? failures + ' width/language combinations with overflow' : 'no overflow anywhere'}`);
+ws.close();

--- a/scripts/rendered-text.mjs
+++ b/scripts/rendered-text.mjs
@@ -1,0 +1,110 @@
+// Captures what a page actually shows, as text, so two builds can be diffed.
+//
+// Usage:  node scripts/rendered-text.mjs <url> <outfile> [language-tag]
+//
+// Why this exists: "nothing visible changed" is a claim, and reading a diff does not check it. Razor
+// drops literal whitespace between an expression and the block that follows, so a change whose diff
+// looks obviously correct can run two sentences together. Capturing the rendered text and diffing that
+// catches it; nothing else did.
+//
+// Why innerText and not textContent or a text-node walk: only innerText reflects what the layout shows.
+// Walking text nodes and trimming each one invents a space wherever two nodes touch. textContent keeps
+// the insignificant whitespace that a wrapped line of markup leaves inside a block element. Both report
+// differences that are not on the screen — and both did, before that was understood.
+//
+// Needs a Chrome listening for the DevTools protocol; see scripts/README.md.
+
+const target = process.argv[2];
+const outfile = process.argv[3];
+const language = process.argv[4];
+
+if (!target || !outfile) {
+  console.error('usage: node scripts/rendered-text.mjs <url> <outfile> [language-tag]');
+  process.exit(2);
+}
+
+const tabs = await (await fetch('http://127.0.0.1:9222/json')).json();
+const page = tabs.find(x => x.type === 'page');
+if (!page) {
+  console.error('no page tab on 127.0.0.1:9222 — see scripts/README.md');
+  process.exit(2);
+}
+
+const ws = new WebSocket(page.webSocketDebuggerUrl);
+await new Promise(r => (ws.onopen = r));
+
+let id = 0;
+const pending = new Map();
+ws.onmessage = e => {
+  const m = JSON.parse(e.data);
+  if (pending.has(m.id)) { pending.get(m.id)(m.result); pending.delete(m.id); }
+};
+const send = (method, params = {}) =>
+  new Promise(res => { const n = ++id; pending.set(n, res); ws.send(JSON.stringify({ id: n, method, params })); });
+const ev = async expression => {
+  const r = await send('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: true });
+  if (r?.exceptionDetails) throw new Error(JSON.stringify(r.exceptionDetails).slice(0, 300));
+  return r.result?.value;
+};
+const wait = ms => new Promise(r => setTimeout(r, ms));
+
+// Wide enough that nothing is in its mobile layout, tall enough that everything is laid out at once.
+await send('Emulation.setDeviceMetricsOverride', { width: 1600, height: 2400, deviceScaleFactor: 1, mobile: false });
+
+// The app is WebAssembly: the first paint is a loading message, and the runtime takes a few seconds
+// cold. Wait for something only the loaded app renders rather than for a fixed delay.
+const load = async () => {
+  await send('Page.navigate', { url: target });
+  for (let i = 0; i < 120; i++) {
+    if (await ev(`document.querySelectorAll('.metrics').length > 0`)) break;
+    await wait(500);
+  }
+  if (!(await ev(`document.querySelectorAll('.metrics').length > 0`))) {
+    console.error('NOT LOADED — the app never finished starting, so the capture would be meaningless');
+    process.exit(1);
+  }
+  await wait(1200);
+};
+
+await load();
+
+// Cleared and reloaded, because the app remembers the last setup and the last language in
+// localStorage. Two builds can only be compared from the same starting state, and a capture that
+// silently inherited the previous run's language is exactly the kind of result that looks fine.
+await ev(`localStorage.clear()`);
+await load();
+
+if (language) {
+  const set = await ev(`(() => {
+    const s = document.querySelector('select.language');
+    if (!s) return 'no language picker';
+    s.value = ${JSON.stringify(language)};
+    s.dispatchEvent(new Event('change', { bubbles: true }));
+    return true;
+  })()`);
+  if (set !== true) { console.error(set); process.exit(1); }
+  await wait(1000);
+}
+
+// Collapsed sections hold real copy, so open them before reading.
+await ev(`document.querySelectorAll('details').forEach(d => (d.open = true)); true`);
+await wait(700);
+
+const text = await ev(`document.body.innerText
+  .split(/[\\r\\n]+/)
+  .map(s => s.replace(/\\s+/g, ' ').trim())
+  .filter(Boolean)
+  .join('\\n')`);
+
+const { writeFileSync } = await import('node:fs');
+writeFileSync(outfile, (text ?? '') + '\n');
+
+// A key that reached the screen means a resource file is missing it — the fallback shows the key
+// itself, which is ugly on purpose so it gets reported. Worth flagging here rather than in a diff.
+const leaked = [...new Set((text ?? '').match(/\b[a-z]+(?:\.[a-zA-Z]+){1,3}\b/g) ?? [])]
+  .filter(s => !/\.(json|js|css|com|org|io|md|png)$/.test(s));
+
+console.log(`captured ${text?.length ?? 0} characters to ${outfile}`);
+if (leaked.length) console.log(`LEAKED KEYS: ${leaked.slice(0, 10).join(', ')}`);
+
+ws.close();

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -1,0 +1,50 @@
+"""Serve the published Blazor output the way a static host does.
+
+Threaded because the runtime pulls dozens of assemblies at once and the stock
+single-threaded handler serialises them into a very long wait. Every unknown path
+falls back to index.html, which is what the Pages 404.html copy does for deep links.
+"""
+import mimetypes
+import os
+import sys
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+ROOT = sys.argv[1]
+PORT = int(sys.argv[2])
+
+for extension, kind in {
+    ".wasm": "application/wasm",
+    ".js": "text/javascript",
+    ".json": "application/json",
+    ".dat": "application/octet-stream",
+    ".blat": "application/octet-stream",
+    ".pdb": "application/octet-stream",
+}.items():
+    mimetypes.add_type(kind, extension)
+
+
+class Handler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=ROOT, **kwargs)
+
+    def end_headers(self):
+        # No caching, so a rebuild is visible on refresh rather than a stale mix of old and new.
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    def send_head(self):
+        path = self.translate_path(self.path)
+        if not os.path.exists(path) and "." not in os.path.basename(path):
+            self.path = "/index.html"
+        return super().send_head()
+
+    def log_message(self, fmt, *args):
+        # Everything, not just failures: when a boot stalls, the useful fact is which file was the
+        # last one fetched, and that is invisible if the successful requests are filtered out.
+        agent = self.headers.get("User-Agent", "")
+        who = "ipad" if "Mobile" in agent or "iPhone" in agent or "iPad" in agent else "other"
+        sys.stderr.write(f"[{who}] {fmt % args}\n")
+        sys.stderr.flush()
+
+
+ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()


### PR DESCRIPTION
First part of #2.

`CONTRIBUTING.md` said "follow coding standards" and "make sure you can build and run the project locally" without saying what the standards are or how the build works. That advice is true of every repository and useful in none. It now says what this one requires.

## What a contributor cannot guess

- The solution is `SYT.NPKTools.slnx`, not a `.sln`
- Warnings are errors, and a public member in `src/` without XML documentation breaks the build
- The assertion library is **AwesomeAssertions**, not FluentAssertions
- Test projects inherit their harness from `tests/Directory.Build.props` — adding a `PackageReference` is wrong
- Not everything under `tests/` is a test project (`OrToolsOracle` is shared support code)
- `InvariantGlobalization=true` is a safety decision, not a size one: a culture-aware parser reads `1,5` grams as `15`
- Every user-visible string lives behind a key in eight files, with a test that fails if they disagree
- Terminology comes from the glossary, not from English

Two traps that cost real time here are written down rather than left to be rediscovered: `dotnet publish -o` does not clean the directory, and Blazor does not re-render a child whose parameters have not changed — which is why the acidification card was invisible for several releases.

## The harnesses now ship

The guide describes how an interface change is verified, so the tools it names are in `scripts/`:

| | |
|---|---|
| `serve.py` | serves a published build like a static host, with `application/wasm` |
| `rendered-text.mjs` | captures what the page shows, for diffing two builds |
| `layout-audit.mjs` | every label at ten widths in eight languages; silence is the pass |

Each carries the reason it works the way it does. `innerText` rather than `textContent` or a text-node walk, because only `innerText` knows which whitespace the layout shows — the other two report differences that are not on the screen, and both did. Viewport size through the DevTools protocol, because **headless Chrome silently clamps `--window-size` to about 500 CSS pixels and crops the screenshot**, which produced three phantom "fixes" before it was understood.

`rendered-text.mjs` also clears `localStorage` and reloads before capturing — the app remembers the last setup and the last language, and a capture that inherited the previous run's language is exactly the kind of result that looks fine. Two consecutive runs now produce byte-identical output.

## The audit ships with its own failure in its header

> Read its silence carefully. This harness once reported "no overflow anywhere" while measuring English eight times, because changing the language redrew the header and not the page.

A harness that cannot fail is not a harness. The way to catch that one is to check the languages differ in length before believing a pass, and the header says so.

## Still to do for #2

Architecture and workflow diagrams, an API reference, examples, and an FAQ. Those are their own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam