### PR TITLE
The architecture, and the questions the numbers raise

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,178 @@
+# How SYT.NPKTools is put together
+
+The library answers one question — *what do I weigh out to hit this nutrient profile in this much
+water?* — and everything in it is either part of answering that or part of telling you whether to trust
+the answer.
+
+This document is the map. For what the pieces do, the XML documentation on each public type is the
+authority and ships in the package for IntelliSense; for how to use them, see the
+[README](../README.md).
+
+## The shape of it
+
+Two packages, and one of them exists so the other can have no dependencies at all.
+
+```mermaid
+graph LR
+    subgraph shipped["shipped packages"]
+        core["SYT.NPKTools<br/><i>no dependencies</i>"]
+        di["SYT.NPKTools.DependencyInjection<br/><i>Microsoft.Extensions.DependencyInjection.Abstractions</i>"]
+    end
+    app["web/SYT.NPKTools.Calculator<br/><i>Blazor WebAssembly</i>"]
+    yours["your application"]
+
+    di --> core
+    app --> core
+    yours --> core
+    yours -.optional.-> di
+```
+
+`SYT.NPKTools` referencing nothing is the constraint that makes everything else possible: it is why the
+whole optimizer runs in a browser tab with no server, and why the calculator is a static site. The
+dependency-injection helpers are separate for exactly that reason — a consumer who wants
+`AddNpkTools()` takes the second package, and one who does not takes nothing.
+
+## The pipeline
+
+A recipe is produced in six steps. The calculator app runs all of them whenever an input is committed —
+the fields use `@onchange`, so on blur or Enter rather than on every keystroke — and a library caller can
+stop after any of them.
+
+```mermaid
+flowchart TD
+    text["<b>1. A target</b><br/>N=150 P=50 K=210 L=100"]
+    parse["IPpmTargetParser<br/>→ PpmTarget"]
+    water["<b>2. The source water</b><br/>WaterProfile"]
+    adjust["target.AdjustFor(water)<br/>→ WaterAdjustedTarget<br/>+ Excesses"]
+    acid["<b>3. Acid, if any</b><br/>AcidDose.Calculate<br/>→ AcidPlan"]
+    shelf["<b>4. The shelf</b><br/>NpkTools.CreateBundleRepository(salts)"]
+    solve["<b>5. The search</b><br/>IFertilizerOptimizationService<br/>.FindMacroSolutions<br/>→ Solutions"]
+    judge["<b>6. Judgement</b><br/>IPpmCalculationService,<br/>NutrientRatios, IonBalance,<br/>ConductivityEstimate"]
+    conc["AsConcentrate(litres)<br/>→ ConcentratePlan<br/>tanks A and B + warnings"]
+
+    text --> parse --> adjust
+    water --> adjust
+    acid --> adjust
+    shelf --> solve
+    adjust --> solve
+    solve --> judge --> conc
+```
+
+**Step 2 is the one other calculators skip.** Whatever the water already supplies is subtracted from the
+target before the optimizer ever sees it, and anything the water oversupplies is reported as an
+`Excess` rather than silently ignored — fertilizer only adds, so no recipe can bring calcium down once
+the water has 160 ppm of it. Saying so is the useful behaviour.
+
+**Step 3 folds into step 2 on purpose.** An acid's nitrogen, phosphorus or sulfur is in the reservoir
+exactly as the water's is, so the acid is added to the water profile the recipe is solved against and
+reported in the tank contents. Getting this wrong understates the tank by the whole dose, which is how
+it was caught: a target of 150 ppm N reported 121.
+
+## Inside the search
+
+`FindMacroSolutions` is not one linear program. It is one per *bundle* — a subset of the shelf — and the
+bundles are generated from what you ticked.
+
+```mermaid
+flowchart LR
+    shelf["the ticked salts"] --> gen["bundle generation<br/>the whole shelf, then the shelf<br/>minus each salt in turn"]
+    gen --> lp["for each bundle:<br/>OptimizationProblem"]
+    lp --> map["IOptimizationProblemMapper"]
+    map --> solver["IOptimizationProblemSolver<br/><i>SimplexOptimizationSolver</i>"]
+    solver --> weights["weights, or nothing"]
+    weights --> dedupe["distinct recipes<br/>→ Solutions"]
+```
+
+Three consequences worth knowing before changing anything here:
+
+- **Coverage is reported, not enforced.** `UncoveredElements` names what nothing on the shelf supplies,
+  and it is shown when no recipe was found — but it is advisory. No filter disqualifies a bundle for
+  missing an element, and a two-salt shelf does solve a target whose other elements are zero. What makes
+  a small shelf fail is that `RangeFactor` defaults to 1, which turns every non-zero element into an
+  exact equality: the mix is over-constrained rather than disqualified. Loosen the range factor and
+  shelves that "cannot" solve begin to.
+- **Bundles are not combinations.** The generator takes the whole shelf, then the shelf minus each salt in
+  turn, capped by `MaxBundles`. That is `n + 1` linear programs for `n` salts, not `2ⁿ` — which is why the
+  search is fast enough to run on every edit, and why it is not exhaustive.
+- **The default solver is fully managed.** `SimplexOptimizationSolver` is why this runs in WebAssembly.
+  `IOptimizationProblemSolver` is a seam: the differential tests substitute OR-Tools and check the two
+  agree, which is how the managed one earns trust.
+- **The search can take a noticeable time**, because it is a linear program per bundle. Every
+  `Find…` method takes a `CancellationToken`.
+
+## Namespaces, and what lives where
+
+| Namespace | What it holds |
+|---|---|
+| `SYT.NPKTools` | `NpkTools` — the static factory that is the whole entry point — plus `Solution`, `Solutions`, the curated catalogue, the bundle repositories and both service interfaces |
+| `SYT.NPKTools.Nutrients` | the domain: `Ppm`, `PpmTarget`, `WaterProfile`, `Acid`, `AcidDose`, `ElementGroups`, `NutrientRatios`, `IonBalance`, conductivity |
+| `SYT.NPKTools.Fertilizers` | what a salt is: `Fertilizer`, `FertilizerBuilder`, `ChemicalFormula`, `FormulaComposition` |
+| `SYT.NPKTools.Optimization` | the search: contracts, the simplex solver, the problem mapper, settings |
+| `SYT.NPKTools.Concentrates` | A/B tanks, solubility, saturation, `ConcentratePlan` and its warnings |
+| `SYT.NPKTools.Internal` | not public API; do not reach into it |
+
+**Folder names are not namespaces here.** The files under `Presets/` and `Optimization/Contracts/`
+declare `namespace SYT.NPKTools` and `namespace SYT.NPKTools.Optimization`; a `<see cref="..."/>` written
+from the folder path will not compile.
+
+Seven public interfaces: `IPpmTargetParser`, `IPpmCalculationService`, `IFertilizerOptimizer`,
+`IFertilizerOptimizationService`, `IFertilizerBundleRepository`, `IOptimizationProblemMapper`,
+`IOptimizationProblemSolver`. Six are reachable through `NpkTools`; the exception is
+`IOptimizationProblemMapper`, which `CreateOptimizer` constructs itself with no overload to pass one, so
+substituting a mapper means building `FertilizerOptimizationAdapter` directly.
+
+## Two design rules that explain most of the code
+
+**A value object rather than a `double`.** `Ppm`, `Weight`, `Liters`, `Percent` and the rest exist so
+that a number cannot arrive in the wrong slot. This is verbose and it is the point: the failure it
+prevents — grams where litres were meant — produces a plausible recipe rather than an exception.
+
+**A figure that comes from the physical world carries its provenance.** The EC model is checked against
+certified KCl conductivity standards, the solubility table against published handbook values, the atomic
+masses against IUPAC. Where a figure could not be sourced, the code says so and the app reports it as
+unknown — `ConcentratePlan.UnknownSolubility` exists because "no published figure" is different from
+"fine", and a ceiling computed without it may be lower than it looks.
+
+## The browser app
+
+`web/SYT.NPKTools.Calculator` is a reference application as much as a product: it demonstrates that the
+library runs client-side with no backend at all.
+
+```mermaid
+flowchart TD
+    home["Pages/Home.razor<br/><i>composes, does not calculate</i>"]
+    model["CalculatorModel<br/><i>singleton: the whole state</i>"]
+    lib["SYT.NPKTools"]
+    panels["WaterPanel, AcidPanel, SaltPicker,<br/>StoragePanel, RecipeCard, CustomSaltForm"]
+    state["CalculatorState<br/><i>URL fragment · localStorage · JSON file</i>"]
+    t["Translations<br/><i>eight embedded resource files</i>"]
+
+    home --> model
+    panels --> model
+    model --> lib
+    model <--> state
+    panels --> t
+    home --> t
+    model -. Changed .-> panels
+    t -. Changed .-> panels
+```
+
+The two dotted edges are not decoration. **Blazor does not re-render a child component whose parameters
+have not changed**, and every panel takes one parameter — a callback to the same method on the page,
+equal on every pass. So the model and the translation store each raise an event.
+`WaterPanel`, `AcidPanel`, `SaltPicker` and `StoragePanel` listen to both, because they display computed
+results; `RecipeCard` and `CustomSaltForm` listen for the language only, since their content arrives as
+parameters or is local to the form. Without the first, the acidification card never appeared at all; without the second, a
+language change redrew the header and nothing else. Both shipped broken before they were measured.
+
+State lives in one singleton and travels three ways, each answering a different question: the URL
+fragment moves a setup to another device, `localStorage` survives closing the tab, and a JSON file
+survives clearing site data. There is no server, so there is nothing else it could be.
+
+## Where to read next
+
+- [README](../README.md) — what each capability is for, with worked examples
+- [CONTRIBUTING](../CONTRIBUTING.md) — the conventions, and how an interface change is verified
+- [`docs/faq.md`](faq.md) — the questions the numbers raise
+- [`docs/superpowers/glossary-hydroponics.md`](superpowers/glossary-hydroponics.md) — the terminology,
+  per language, with sources and with the gaps marked

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,175 @@
+# Questions the numbers raise
+
+Most of these are not bugs. They are the calculator telling you something about your water, your shelf
+or your bag that is easy to mistake for a fault — and each answer says which.
+
+If something here turns out to be a real fault, the fastest bug report is **the link the app puts in the
+address bar**: it carries the whole setup, so the problem is reproducible exactly.
+
+## "No recipe for this combination"
+
+Two different failures wear the same words, and the message tells you which one you have.
+
+**"Nothing on the shelf supplies X."** Nothing you ticked contains that element, so a target asking for
+it cannot be met. Tick a source. Worth knowing how literal this is not: the element is *reported*, not
+enforced — a shelf with no magnesium will still solve a target whose magnesium is zero — so the message
+appears when the search found nothing and there is also a gap worth naming.
+
+**"The selected salts cannot reach this target."** Everything asked for is available somewhere on the
+shelf, but no mix lands inside tolerance. Two causes, in order of likelihood. The target may be
+internally impossible with those salts: potassium nitrate carries nitrogen with its potassium, so high
+potassium with low nitrogen needs a potassium source that is not a nitrate — add potassium sulfate. Or
+the mix is over-constrained: every non-zero element is solved as an exact equality by default, and a
+short shelf has too few degrees of freedom to hit six numbers at once. A longer shelf is the practical
+answer; a library caller can loosen `RangeFactor` instead.
+
+## The tank has more calcium (or nitrogen) than I asked for
+
+Your water already supplied it. **Fertilizer only adds** — there is no salt that removes calcium from
+water — so once the water brings 160 ppm of calcium and the target is 140, no recipe can reach the
+target and the app says so instead of pretending. Raise the target, dilute the water with rain or
+osmosis, or accept it.
+
+The same happens with an acid: nitric acid carries nitrogen, and at a high alkalinity the dose alone can
+overshoot a modest nitrogen target. The acid card names an acid that would fit when one does, which is
+usually phosphoric or sulfuric depending on which element you have room for.
+
+## The predicted EC does not match my meter
+
+Several honest reasons, in the order they are likely:
+
+- **A TDS meter is not an EC meter.** It measures conductivity and multiplies by a factor its
+  manufacturer chose — 500 or 700 are the common ones, and Turkish irrigation literature uses 640.
+  Two meters can disagree by 40% with both being right. The app shows `TDS ×500` so you know which
+  convention it applied.
+- **ppm of an element is not the ppm on a TDS meter.** The app's nutrient figures are milligrams of that
+  element per litre. A TDS reading is a conductivity proxy for everything dissolved. They are different
+  quantities and should not be compared.
+- **You acidified.** The recipe's EC still counts the bicarbonate the acid removed, so after acidifying
+  the prediction reads high — by roughly 44.5 µS/cm per meq/L neutralised. The acid card says so with
+  the figure for your water.
+- **The solution is stronger than the model was checked against.** The EC model is validated against
+  certified KCl standards up to the ionic strength of a normal feed; a concentrate at 1:100 is an order
+  of magnitude past that. When you are outside the validated range the app says *EC out of range* and
+  the figure should be read as an ordering, not a measurement.
+- **Calibration and temperature.** A meter reads what it was last calibrated to believe.
+
+## My bag says 46% K₂O. What do I type?
+
+Divide first. Labels quote nutrients as **oxides**, and in the EU, Spain, Poland and Turkey that is
+required by law rather than being a convention — so it is not only phosphorus and potassium:
+
+| On the bag | Divide by | To get |
+|---|---|---|
+| P₂O₅ | 2.29 | P |
+| K₂O | 1.20 | K |
+| CaO | 1.40 | Ca |
+| MgO | 1.66 | Mg |
+| SO₃ | 2.5 | S |
+
+A 46% K₂O potassium nitrate is 38% K. Typing 46 overstates potassium by a fifth; on phosphorus the same
+mistake is a factor of 2.29.
+
+Better still, use the **formula** tab when you can and let the app derive the percentages — that is what
+it is for, and it cannot make this mistake.
+
+## The formula tab says my salt "looks like a chelate"
+
+Because it does, and a formula cannot tell the app what matters. Iron EDTA — `C10H12N2O8FeNa` — parses
+fine and yields 7.6% nitrogen, but that nitrogen is holding the iron, not feeding the plant. Entered by formula, the
+salt would offer nitrogen it does not have, and the optimizer would count it. Describe a chelate by
+percentages instead, where the agent is named and the nitrogen is not claimed.
+
+## "Tank B is at 136% of saturation"
+
+The salts in that tank together need more water than the tank holds. Each one alone might dissolve; they
+compete for the same water. Use a larger concentrate volume — a 1:50 concentrate instead of 1:100 — or
+move a salt to the other tank if the pairing allows it.
+
+The related warning, **"Tank B needs 20.3 g/L of X, which dissolves to 18 g/L"**, is about one salt
+rather than the tank: that salt cannot dissolve at that strength at 20 °C whatever else is in there.
+Calcium monobasic phosphate is the usual culprit at 18 g/L, the lowest figure in the table.
+
+## Why does it insist on two tanks?
+
+Calcium and sulfate make gypsum, and calcium and phosphate make a precipitate too. At working strength
+they stay in solution; at concentrate strength they do not. So calcium goes in tank A and sulfates and
+phosphates in tank B, and the app warns if your own salt would put them together.
+
+A single salt that contains both internally — monocalcium phosphate — is *not* flagged, because it is a
+soluble compound rather than two reagents that happen to be adjacent. A check that fired on that would
+train you to ignore it.
+
+## The acid dose is less than my alkalinity. Is that a rounding error?
+
+No, it is the carbonate equilibrium. Neutralising the *whole* alkalinity would take the water to a pH
+below where you want it; at pH 5.8 about three quarters of the alkalinity needs neutralising, not all of
+it. The common rule of thumb overstates the dose by roughly a quarter.
+
+One caveat the app states rather than hides: it is worked for a **closed** vessel. An open reservoir
+loses CO₂ and drifts back up, so the dose you settle on in practice will be nearer the full figure.
+
+## Which pH do I enter?
+
+**Water pH** is the pH of the source water, and it is the one place a pH reading carries real
+information: it locates the water on its titration curve, which is what turns an alkalinity into a dose.
+It says nothing about composition, which is why the app asks for it nowhere else.
+
+**Target pH** is where you want the reservoir. Between 5.5 and 6.2 for most things in soilless growing.
+
+## I typed 1,5 and it read 1.5. Or: why is everything shown with a dot?
+
+Deliberate, in both directions. A comma is accepted as a decimal point because half of Europe types one.
+Display is always a dot, because the app is built without ICU on purpose: a culture-aware parser can
+decide a comma means thousands and read **1,5 grams as 15**, which is a tenfold weighing error. One
+unambiguous output form is worth more than local familiarity when the number is going to be read aloud,
+photographed and pasted across borders.
+
+## There is no acidification card
+
+Your water has no alkalinity to neutralise — which is the case on reverse osmosis, distilled or rain
+water, where there is nothing to decide. Switch the water to EC or Analysis mode and describe real water
+and the card appears.
+
+(If you are on an older build and the card never appears at all, that was a bug: the panel was not being
+redrawn. Fixed.)
+
+## Does any of this leave my browser?
+
+No. There is no server, no account and no telemetry; the whole calculation runs in the page. That is
+also why the app can be used offline once loaded, and why "sync" is a link you copy rather than a service
+you log into.
+
+## Why is the link so long?
+
+It carries the whole setup — the target, the water, the acid, the ticked salts, your own salts — in the
+address itself, so pasting it into another browser reproduces exactly what you were looking at. Nothing
+was uploaded anywhere to make that work.
+
+If a link was made against a different version of the catalogue, the app applies everything it can, says
+that the salt selection was ignored, and ticks everything rather than silently dropping salts.
+
+## The estimated analysis is not an analysis
+
+It says so in the heading. Given a meter reading, the app scales a typical water profile until the
+computed conductivity matches your meter — so the proportions between ions come from the profile you
+chose, not from your water. If you enter a hardness drop test as well, those measurements are pinned and
+only what is left over is scaled. It is a much better starting point than assuming pure water, and it is
+not a laboratory result.
+
+If the readings cannot describe the same water — a hardness that already accounts for more conductivity
+than the meter read — the app says that too, rather than producing a profile that is arithmetic rather
+than water.
+
+## Building and running it
+
+- **.NET 10 SDK.** `global.json` pins `10.0.100` with `rollForward: latestFeature`; a 9.x SDK will not do.
+- The solution is **`SYT.NPKTools.slnx`**. Bare `dotnet build` and `dotnet test` find it.
+- **A published app served from a plain file server shows nothing.** The WebAssembly runtime needs
+  `application/wasm` on the `.wasm` files and a fallback to `index.html` for deep links.
+  `scripts/serve.py` does both; `python3 -m http.server` does neither.
+- **`dotnet publish -o <dir>` does not clean the directory.** Stale assemblies accumulate and you debug a
+  build that is not the one you think. Remove it first.
+
+For the conventions, the test harness and how an interface change is verified, see
+[CONTRIBUTING](../CONTRIBUTING.md). For the shape of the code, [architecture](architecture.md).


### PR DESCRIPTION
Part of #2. `docs/architecture.md` — how the library is put together, with mermaid diagrams of the pipeline, the search and the app. `docs/faq.md` — the things a grower mistakes for a fault, and which of them are one.

## A reviewer checked every claim against the code, and found seven errors

That was the point of running it, and one finding matters beyond these documents.

**A macro bundle does not have to cover all six macronutrients.** I believed there was a coverage filter. There is not. `UncoveredElements` is computed for reporting and surfaced only when nothing was found; no bundle is disqualified for missing an element. The reviewer demonstrated it: a two-salt shelf, `UncoveredElements = [Ca, Mg, S]`, and **one solution** for a target whose other elements are zero.

What actually makes a short shelf fail is that `RangeFactor` defaults to 1, which turns every non-zero element into an exact equality. The mix is over-constrained, not disqualified — and that is a far more useful answer for somebody whose shelf "cannot" solve, because loosening the range factor fixes it.

I asserted the coverage rule in earlier pull requests too. It was wrong there as well.

The other six:

| Claimed | Actually |
|---|---|
| bundles are "every combination that covers all six macros" | the whole shelf, then the shelf minus each salt in turn, capped by `MaxBundles` — `n + 1` programs, not `2ⁿ`, and not exhaustive |
| iron EDTA yields ~6.5% N | 7.6% for `C10H12N2O8FeNa`; 6.5% is the trihydrate |
| namespace `SYT.NPKTools.Presets` | does not exist — those files declare `namespace SYT.NPKTools` |
| seven interfaces all substitutable via `NpkTools` | six; `CreateOptimizer` builds `IOptimizationProblemMapper` itself with no overload |
| "every panel listens to both events" | four do; `RecipeCard` and `CustomSaltForm` listen for the language only |
| "runs on every keystroke" | on commit — the fields use `@onchange` |

The namespace one earned a warning of its own in the document: **folder names are not namespaces in this repository**, so a `<see cref="..."/>` written from the folder path will not compile. That has bitten before.

## What the FAQ covers

The questions where the honest answer is "that is your water, not a bug": more calcium in the tank than you asked for, a predicted EC that disagrees with your meter and the five separate reasons why, why the acid dose is less than the alkalinity, why a concentrate saturates, and what to type when the bag says 46% K₂O. Every number in it was verified — the oxide divisors, 46% K₂O ≈ 38% K, 44.5 µS/cm per meq/L, and the three-quarters figure at pH 5.8, which the reviewer recomputed from `AcidDose.BicarbonateFraction` rather than taking the sentence's word for it (0.768 at water pH 7.6).

Five claims could not be checked against code because they are domain facts rather than behaviour — the Turkish ×640 factor, oxide labelling being legally required, CO₂ drift in an open reservoir, the target pH range. Those come from the glossary, where they carry their sources.

## Still open on #2

An API reference, and worked examples as tested code rather than prose. Those are the next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam