### PR TITLE
An API reference, and worked examples that are tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ the browser under WebAssembly.
 dotnet add package SYT.NPKTools
 ```
 
+**Documentation:** [worked examples](docs/examples.md) (every one of them a test) ·
+[API reference](docs/api-reference.md) · [architecture](docs/architecture.md) ·
+[FAQ](docs/faq.md) · [contributing](CONTRIBUTING.md)
+
 > **This is `1.0.0-preview.3`.** It supersedes the `NPKTools.*` packages, which are no longer
 > updated. If you are coming from those, see [Migrating from NPKTools 1.x](#migrating-from-npktools-1x).
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,237 @@
+# API reference
+
+**The XML documentation is the authority**, and it ships inside the package, so your IDE already knows more
+about a signature than this page can. CS1591 is enforced in `src/`, which means a new public member without
+a `<summary>` breaks the build — with carve-outs worth knowing about, because they are exactly the members
+you will look up and not find. `.editorconfig` switches it off for `ValueObjects/`, `Builders/` and
+`Internal/`, so every `FertilizerBuilder.Add…` method and every value object's `.Value` is undocumented by
+design.
+
+What this page gives you is the shape: which of the public types you actually touch, in what order, and
+which of them you can substitute.
+
+For working code see [examples](examples.md); every snippet there is a test. For why it is arranged this
+way, [architecture](architecture.md).
+
+## The entry point
+
+`NpkTools` is a static factory in namespace `SYT.NPKTools`, and it is the whole entry point. Nothing else
+needs constructing by hand.
+
+| Method | Returns | Use it when |
+|---|---|---|
+| `CreateTargetParser()` | `IPpmTargetParser` | you have a target as a string |
+| `CreateOptimizationService(IOptimizationProblemSolver? solver = null)` | `IFertilizerOptimizationService` | you want recipes from the curated catalogue |
+| `CreateOptimizationService(IEnumerable<Fertilizer> salts, BundleGenerationSettings? settings = null, IOptimizationProblemSolver? solver = null)` | `IFertilizerOptimizationService` | you want recipes from your own shelf |
+| `CreateOptimizer(IOptimizationProblemSolver? solver = null)` | `IFertilizerOptimizer` | you want one linear program over one list of salts, not a search |
+| `CreatePpmCalculator()` | `IPpmCalculationService` | you have weights and want to know what is in the tank |
+| `CreateBundleRepository()` | `IFertilizerBundleRepository` | you want the catalogue's own bundles |
+| `CreateBundleRepository(IEnumerable<Fertilizer> salts, BundleGenerationSettings? settings = null)` | `CustomFertilizerBundleRepository` | you want bundles from your own shelf |
+
+The `solver` parameter defaults to `SimplexOptimizationSolver`, which is fully managed and therefore works
+everywhere .NET runs, WebAssembly included. That default is why the calculator is a static site.
+
+## The interfaces
+
+Seven, all public, spread over three namespaces — `SYT.NPKTools.Nutrients`, `SYT.NPKTools` and
+`SYT.NPKTools.Optimization`.
+
+```csharp
+// SYT.NPKTools.Nutrients
+PpmTarget Parse(string input);                                                    // IPpmTargetParser
+Ppm CalculatePpm(IReadOnlyList<Fertilizer> collection, double waterLiters = 1);   // IPpmCalculationService
+
+// SYT.NPKTools — the search
+Solutions FindMacroSolutions(PpmTarget target, CancellationToken cancellationToken = default);   // IFertilizerOptimizationService
+Solutions FindMicroSolutions(PpmTarget target, CancellationToken cancellationToken = default);
+FertilizerSolutions FindSolutions(PpmTarget target, CancellationToken cancellationToken = default);
+IReadOnlyList<IReadOnlyList<Fertilizer>> Macro();                                        // IFertilizerBundleRepository
+IReadOnlyList<IReadOnlyList<Fertilizer>> Micro();
+
+// SYT.NPKTools.Optimization — the seams
+Solution? Optimize(PpmTarget target, IReadOnlyList<Fertilizer> sourceCollection, SolutionFinderSettings settings);   // IFertilizerOptimizer
+OptimizationProblem CreateOptimizationProblem(PpmTarget target, IReadOnlyList<Fertilizer> sourceCollection, SolutionFinderSettings settings);   // IOptimizationProblemMapper
+Solution? CreateSolution(Dictionary<string, double> solutionValues, IReadOnlyList<Fertilizer> originalSourceCollection, double waterLiters = 1);
+Dictionary<string, double>? Solve(OptimizationProblem problem);                                            // IOptimizationProblemSolver
+```
+
+**Every `Find…` takes a `CancellationToken`, and you should pass one.** Each call runs a linear program per
+bundle, so a large shelf takes a noticeable amount of time.
+
+**Only one of the seven is substitutable through `NpkTools`:** `IOptimizationProblemSolver`, which every
+factory method takes as an optional parameter. The mapper, the bundle repository and the optimizer are all
+constructed internally with no overload to pass your own, so replacing any of those means building
+`FertilizerOptimizationService` or `FertilizerOptimizationAdapter` yourself. That is a deliberate
+narrowness — the solver is the seam anyone actually needs — but it is worth knowing before you plan around
+an interface you cannot inject.
+
+`IOptimizationProblemSolver` is the seam that matters. The managed simplex is the default; the repository's
+differential tests substitute OR-Tools and check that the two agree, which is how the managed one earns
+being trusted.
+
+## What you get back
+
+**`Solutions`** is `IReadOnlyList<Solution>` with a `Solutions.Empty`. Several recipes are returned because
+several reach the target; they differ in which salts they use. Nothing is "best" — that depends on what is
+on your shelf and what you would rather spend.
+
+**`Solution`** is `IReadOnlyList<Fertilizer>` plus `WaterLiters`. Each `Fertilizer` in it carries the
+`Weight` to measure out.
+
+**`FertilizerSolutions(Solutions Macro, Solutions Micro)`** — what `FindSolutions` returns, with
+`IsEmpty` and `FertilizerSolutions.Empty`.
+
+**`Ppm`** — what is actually in the tank, one property per element (`Nitrogen`, `Phosphorus`, … `Sodium`),
+each a value object with a `.Value`, plus `Liters` and `Report()`. Six extension methods turn it into the
+other things a grower reads:
+
+```csharp
+// PpmExtensions
+ConductivityEstimate EstimateConductivity(this Ppm ppm, double bicarbonateMeqPerLitre = 0);
+MolarProfile AsMillimolar(this Ppm ppm);        // mM, how a feed chart is written
+NutrientRatios Ratios(this Ppm ppm);           // NO₃:NH₄, K:Ca, Ca:Mg …
+IonBalance IonBalance(this Ppm ppm);           // the same solution as charges, in meq/L
+Ppm Plus(this Ppm ppm, Ppm other);             // what the water and the salts come to together
+string Breakdown(this Ppm ppm);                // one line per element, for a log
+```
+
+The bicarbonate parameter on the first is not decoration: a water's bicarbonate conducts, so leaving it at
+zero understates the EC of anything mixed into real water.
+
+**`ConductivityEstimate`** — `MilliSiemensPerCm`, `MicroSiemensPerCm`, `IdealMicroSiemensPerCm`,
+`AsTdsPpm(double scale = 500)`, a property per ion's contribution, `IonicStrength`, `Correction`,
+`ValidatedIonicStrength` and **`IsWithinValidatedRange`**. Check the last one: the model is validated
+against certified KCl standards up to the ionic strength of a normal feed, and a concentrate is an order of
+magnitude past it.
+
+**`NutrientRatios`** — `NitrateToAmmonium`, `NitrogenToPotassium`, `PotassiumToCalcium`,
+`CalciumToMagnesium`, `PotassiumToMagnesium`, `NitrogenToSulfur`, `NitrogenToPhosphorus`, `TotalPpm`. Each
+ratio is `double?`, null when the denominator is zero — a null is not a zero, and displaying it as one
+would be a lie about the mix.
+
+**`IonBalance`** — the same solution as charges in meq/L per ion, plus `Total`, `AcidEquivalents`,
+`RelativeDifference` and `IsChargeNeutral`. This is what makes a charge imbalance visible, and
+`AcidEquivalents` is how the app reports what the acid contributed.
+
+## The target and the water
+
+**`PpmTarget`** — one property per element named by symbol (`N`, `P`, `K`, `Ca`, `Mg`, `S`, `Fe`, `Cu`,
+`Mn`, `Zn`, `B`, `Mo`, `Cl`, `Si`, `Se`, `Na`) plus `Liters`. `IPpmTargetParser.Parse` reads
+`"N=150 P=50 K=210 L=100"`; `L` is the reservoir volume.
+
+**`WaterProfile`** — built with `WaterProfileBuilder`, and the piece other calculators do not have:
+
+```csharp
+WaterAdjustedTarget AdjustFor(this PpmTarget target, WaterProfile water);
+double EstimatedAlkalinity(this WaterProfile water);     // meq/L, from the cation surplus
+double GeneralHardness(this WaterProfile water);          // °dH
+double CarbonateHardness(this WaterProfile water);        // °dH
+ConductivityEstimate EstimateConductivity(this WaterProfile water);
+Ppm AsPpm(this WaterProfile water);                        // the water as a Ppm, to add to a recipe
+```
+
+**`WaterAdjustedTarget(PpmTarget Target, IReadOnlyList<NutrientExcess> Excesses)`**, with `HasExcesses`.
+Pass `Target` to the optimizer. Read `Excesses` — each is
+`NutrientExcess(string Element, double InWater, double Target)` with `Overshoot` — because fertilizer only
+adds, and an element the water oversupplies is a thing no recipe can fix.
+
+**`WaterPreset`** — four shapes of real water (`SoftLowAlkalinity`, `CalciumBicarbonateModerate`,
+`CalciumBicarbonateHard`, `SodiumExchangeSoftened`, and `All`), each with `Id`, `Label`, its per-element
+proportions, `NominalMicroSiemensPerCm` and `ToProfile(scale)`.
+**`WaterEstimator.Estimate(WaterPreset preset, double microSiemensPerCm, double? generalHardness = null,
+double? carbonateHardness = null)`** scales a preset until its computed conductivity matches a meter
+reading. It returns a `WaterEstimate` — `Profile`, `MicroSiemensPerCm`, `RequestedMicroSiemensPerCm`,
+`RelativeError`, `Feasible` — which you read rather than construct; its constructor is internal.
+
+`Feasible` is false in either direction: when a hardness already accounts for more conductivity than the
+meter saw, and when the reading is higher than the preset reaches at full scale. Both mean the readings do
+not describe one water, which is worth saying rather than returning arithmetic.
+
+## Salts
+
+**`Fertilizer`** is built with `FertilizerBuilder`: `AddName`, `AddType`, then one `Add…` per nutrient
+form — `AddNo3`, `AddNh4`, `AddNh2`, `AddP`, `AddK`, `AddCaNonChelated`, `AddCaEdta`, `AddMgNonChelated`,
+`AddS`, the micronutrients and their chelates — then `AddWeight` and `Build()`. The chelated and
+non-chelated forms are separate members on purpose: a chelate behaves differently and the library will not
+guess which you meant.
+
+**`ChemicalFormula`** derives the percentages instead of trusting typed ones:
+
+```csharp
+static bool TryParse(string? text, out ChemicalFormula? formula, out FormulaProblem? problem);
+double MolarMass { get; }
+double PercentOf(string symbol);
+double NitratePercent, AmmoniumPercent, AmidePercent { get; }
+IReadOnlyDictionary<string, int> Atoms { get; }
+```
+
+Accepts plain and Unicode subscripts, bracketed groups, and hydrates joined by `*`, `·`, `×` or `.`.
+**`FormulaProblem(FormulaProblemKind Kind, string Message, string? Value, int? Position)`** names the
+failure rather than only describing it, so a caller can write its own sentence in its own language.
+
+**`FormulaComposition`** — `TryCreate(name, formula, type, out Fertilizer?, out FormulaProblem?)`,
+`SuggestTank(formula)`, and `LooksChelated(formula)`. The last one matters: iron EDTA parses fine and
+yields 7.6% nitrogen that is holding the metal rather than feeding the plant, and a formula cannot tell the
+two apart.
+
+## Acid
+
+```csharp
+static AcidPlan Calculate(
+    double alkalinityMilliequivalentsPerLitre, double waterPh, double targetPh, Acid acid, double litres);
+static double BicarbonateFraction(double ph);
+```
+
+`Acid.All` holds six — nitric, phosphoric and sulfuric at two strengths each — each with `Id`, `Label`,
+`Kind` (an `AcidKind`), `PercentByWeight`, `DensityGramsPerMillilitre`, `EquivalentWeight`,
+`EquivalentsPerLitre`, `NutrientSymbol` and `MilligramsOfNutrientPerMilliequivalent`. **`AcidPlan`** gives `MilliequivalentsPerLitre`,
+`Millilitres`, `NutrientSymbol` and `NutrientPpm`.
+
+The dose is less than the alkalinity, and that is the point: worked from the carbonate equilibrium, at pH
+5.8 about three quarters needs neutralising, where the rule of thumb says all of it. Subtract
+`NutrientPpm` from the target as you would the water — an acid's nitrogen is in the reservoir exactly as
+the water's is.
+
+## Concentrates
+
+```csharp
+static ConcentratePlan AsConcentrate(this Solution solution, double concentrateLiters, SolubilityTable? solubility = null);
+```
+
+**`ConcentratePlan`** — `TankA`, `TankB`, `Tanks`, `ConcentrateLiters`, `WorkingLiters`,
+`DilutionRatio`, `MillilitresPerLiter`, `MaxDilutionRatio`, `Warnings`, `HasWarnings`,
+`HasPrecipitationRisk`, `ExceedsSolubility`, and `UnknownSolubility`.
+
+That last one is the honest part: a salt with no published figure is named there rather than assumed to be
+fine, so `MaxDilutionRatio` excludes it and the real ceiling may be lower than it looks.
+
+**`ConcentrateTank(ConcentrateType Tank, IReadOnlyList<ConcentrateComponent> Components)`** —
+`TotalGrams`, `TotalGramsPerLiter`, `SaturationFraction`, `IsSaturated`, `IsEmpty`. Each
+**`ConcentrateComponent`** carries its `Fertilizer`, `Grams`, `GramsPerLiter`, `SolubilityLimit` and
+`ExceedsSolubility`.
+
+**`ConcentrateWarning(ConcentrateWarningKind Kind, ConcentrateType Tank, IReadOnlyList<string> Fertilizers, string Message, double? Actual, double? Allowed)`**.
+Four kinds: `PrecipitationRisk`, `SolubilityExceeded`, `TankSaturated`, `TankInferred`. `Message` is prose
+for a log; `Actual` and `Allowed` carry the two figures so an application can write the sentence in the
+reader's language.
+
+## Grouping and settings
+
+**`ElementGroups`** — `Macro` (six), `Micro` (eight), `CounterIons` (Cl and Na), `All` (sixteen). Use these
+rather than writing the lists out; they are what the app's grids iterate.
+
+**`SolutionFinderSettings`** controls the search, and one field explains most surprises: `RangeFactor`
+defaults to **1, which is the tightest it goes** — every element the target names becomes an exact
+equality, and a value above 1 is rejected. So a short shelf that "cannot" solve is usually
+over-constrained rather than short of an element, and the way to loosen it is to *lower* the factor.
+
+One nuance worth having: an element the target does not mention at all is unconstrained, but an element
+you explicitly set to zero is pinned to zero. `Ca=0` is a requirement, not a shrug.
+`BundleGenerationSettings.MaxBundles` caps how many subsets of your shelf are tried.
+
+## What is not API
+
+`SYT.NPKTools.Internal` is not public API whatever its accessibility says. And **folder names are not
+namespaces here**: the files under `Presets/` and `Optimization/Contracts/` declare `namespace
+SYT.NPKTools` and `namespace SYT.NPKTools.Optimization`, so a `<see cref="..."/>` written from the folder
+path will not compile.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,10 +87,11 @@ Three consequences worth knowing before changing anything here:
 
 - **Coverage is reported, not enforced.** `UncoveredElements` names what nothing on the shelf supplies,
   and it is shown when no recipe was found — but it is advisory. No filter disqualifies a bundle for
-  missing an element, and a two-salt shelf does solve a target whose other elements are zero. What makes
-  a small shelf fail is that `RangeFactor` defaults to 1, which turns every non-zero element into an
-  exact equality: the mix is over-constrained rather than disqualified. Loosen the range factor and
-  shelves that "cannot" solve begin to.
+  missing an element, and a two-salt shelf does solve a target that does not mention the others. What makes
+  a small shelf fail is that `RangeFactor` defaults to 1 — the tightest it goes — which turns every element
+  the target names into an exact equality: the mix is over-constrained rather than disqualified. *Lower* the
+  factor and shelves that "cannot" solve begin to. An element the target never mentions is unconstrained;
+  one you set to zero is pinned to zero.
 - **Bundles are not combinations.** The generator takes the whole shelf, then the shelf minus each salt in
   turn, capped by `MaxBundles`. That is `n + 1` linear programs for `n` salts, not `2ⁿ` — which is why the
   search is fast enough to run on every edit, and why it is not exhaustive.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,258 @@
+# Worked examples
+
+**Every example on this page is a test.** They live in
+[`tests/SYT.NPKTools.IntegrationTests/DocumentedExamplesTests.cs`](../tests/SYT.NPKTools.IntegrationTests/DocumentedExamplesTests.cs)
+and run in CI, so if an API moves the build fails rather than the reader. Copying from here is safe in a
+way that copying from prose is not.
+
+```bash
+dotnet test tests/SYT.NPKTools.IntegrationTests --filter "FullyQualifiedName~DocumentedExamples"
+```
+
+## The shortest thing that works
+
+```csharp
+IPpmTargetParser parser = NpkTools.CreateTargetParser();
+IFertilizerOptimizationService optimizer = NpkTools.CreateOptimizationService();
+
+PpmTarget target = parser.Parse("N=150 P=50 K=210 Ca=160 Mg=50 S=65 L=100");
+Solutions recipes = optimizer.FindMacroSolutions(target);
+
+Solution recipe = recipes[0];          // several are returned; they differ in which salts they use
+double liters = recipe.WaterLiters;     // 100
+foreach (Fertilizer salt in recipe)
+{
+    Console.WriteLine($"{salt.Name.Value}: {salt.Weight.Value:F2} g");
+}
+```
+
+`L=100` in the target string is the reservoir volume in litres. `Solutions` is a list — every entry hits
+the target, and they differ in which salts they use, so the choice between them is about what you have
+and what you would rather spend.
+
+## What the water already supplies comes off the target
+
+This is the step most calculators skip, and it is the difference between a recipe and a guess.
+
+```csharp
+PpmTarget target = NpkTools.CreateTargetParser().Parse("N=150 K=210 Ca=160 Mg=50 S=65 L=100");
+WaterProfile water = new WaterProfileBuilder().AddCa(60).AddMg(12).Build();
+
+WaterAdjustedTarget adjusted = target.AdjustFor(water);
+
+adjusted.Target.Ca.Value;   // 100 — the water brought 60 of the 160
+adjusted.Target.Mg.Value;   // 38
+adjusted.Excesses;          // empty
+```
+
+Pass `adjusted.Target` to the optimizer, not the original. On hard water the difference is the whole
+point: ignore it and you overdose calcium by exactly what the water carried.
+
+## Water that oversupplies is reported, not ignored
+
+```csharp
+PpmTarget target = NpkTools.CreateTargetParser().Parse("N=150 K=210 Ca=100 L=100");
+WaterProfile hardWater = new WaterProfileBuilder().AddCa(160).Build();
+
+WaterAdjustedTarget adjusted = target.AdjustFor(hardWater);
+
+NutrientExcess excess = adjusted.Excesses[0];
+excess.Element;     // "Ca"
+excess.InWater;     // 160
+excess.Target;      // 100
+excess.Overshoot;   // 60
+```
+
+**Fertilizer only adds.** There is no salt that removes calcium from water, so once the water carries
+more than the target no recipe can reach it. Saying which element and by how much is the only useful
+answer; silently clamping to zero would produce a recipe that looks fine and is not.
+
+## Your own shelf instead of the catalogue
+
+```csharp
+Fertilizer[] shelf =
+[
+    new FertilizerBuilder().AddName("Calcium Nitrate Tetrahydrate").AddType(ConcentrateType.A)
+        .AddNo3(11.86).AddCaNonChelated(16.97).Build(),
+    new FertilizerBuilder().AddName("Potassium Nitrate").AddType(ConcentrateType.A)
+        .AddNo3(13.85).AddK(38.67).Build(),
+    new FertilizerBuilder().AddName("Magnesium Sulfate Heptahydrate").AddType(ConcentrateType.B)
+        .AddMgNonChelated(9.86).AddS(13.01).Build(),
+    new FertilizerBuilder().AddName("Monopotassium Phosphate").AddType(ConcentrateType.B)
+        .AddP(22.76).AddK(28.73).Build(),
+    new FertilizerBuilder().AddName("Potassium Sulfate").AddType(ConcentrateType.B)
+        .AddK(44.87).AddS(18.4).Build(),
+    new FertilizerBuilder().AddName("Ammonium Nitrate").AddType(ConcentrateType.A)
+        .AddNo3(17.5).AddNh4(17.5).Build(),
+];
+
+IFertilizerOptimizationService optimizer = NpkTools.CreateOptimizationService(shelf);
+Solutions recipes = optimizer.FindMacroSolutions(target);
+```
+
+**Six salts, and that is not an accident.** The first four — calcium nitrate, potassium nitrate,
+magnesium sulfate and MKP — cannot hit this six-element target at all, and writing this example is how
+that was found out. Adding potassium sulfate as the fifth gives one recipe; ammonium nitrate as the sixth
+gives two. By default every element the target names is solved as an *exact* equality, so six numbers need
+about six independent knobs, and four salts whose elements are pairwise tied leave the problem
+over-constrained rather than short of an ingredient.
+
+If your own shelf "cannot" solve, that is usually why. Two ways out: add a salt that supplies one element
+more independently — potassium sulfate is the classic, because it frees potassium from nitrogen — or
+**lower** `RangeFactor` in `SolutionFinderSettings` below its default of 1, which turns the equalities
+into ranges. Note the direction: 1 is the tightest it goes, and a value above 1 is rejected.
+
+`AddType` decides which concentrate tank a salt belongs in — `A` for calcium, `B` for sulfates and
+phosphates. It matters only if you make a concentrate, and then it matters a lot.
+
+## A salt from its chemical formula
+
+The safe way to add a salt, because the percentages are derived instead of typed.
+
+```csharp
+if (ChemicalFormula.TryParse("KNO3", out ChemicalFormula? formula, out FormulaProblem? problem))
+{
+    formula!.MolarMass;              // 101.10
+    formula.PercentOf("K");          // 38.67
+    formula.NitratePercent;          // 13.85
+}
+
+FormulaComposition.TryCreate("Shop KNO3", "KNO3", ConcentrateType.A, out Fertilizer? salt, out _);
+```
+
+Hydrates are written with `*`, `·`, `×` or `.` — `Ca(NO3)2*4H2O` — and both plain and subscript digits are
+accepted, because the catalogue mixes them within a single formula.
+
+**Why this beats typing percentages:** a bag quotes P₂O₅ and K₂O, and in the EU, Spain, Poland and
+Turkey that is required by law rather than being a convention. A figure copied straight off the label
+overstates phosphorus by 2.29× — and it is not only P and K, since the same rules quote calcium and
+magnesium as CaO and MgO. A formula cannot make that mistake. See
+[the FAQ](faq.md#my-bag-says-46-ko-what-do-i-type) for the divisors when you have no formula.
+
+**Do not describe a chelate by formula.** Iron EDTA parses fine and yields 7.6% nitrogen — nitrogen that
+is holding the iron, not feeding the plant. `FormulaComposition.LooksChelated` exists to warn about
+exactly this; describe a chelate by percentages, where the agent is named.
+
+## A formula that cannot be read says which failure it is
+
+```csharp
+ChemicalFormula.TryParse("KNO3!", out _, out FormulaProblem? problem);   // false
+
+problem!.Kind;       // FormulaProblemKind.UnexpectedCharacter
+problem.Value;       // "!"
+problem.Position;    // 5
+```
+
+`Message` carries English prose for a log. `Kind`, `Value` and `Position` are there so an application can
+write its own sentence, in its own language — which is what the browser app does, because this message
+reaches somebody who has just made a typo.
+
+## Judging the mix, not just computing it
+
+```csharp
+Ppm inTank = NpkTools.CreatePpmCalculator().CalculatePpm(recipe, recipe.WaterLiters);
+inTank.Nitrogen.Value;                       // 150, within 1%
+
+ConductivityEstimate ec = inTank.EstimateConductivity();
+ec.MilliSiemensPerCm;                        // what a meter should read
+ec.IsWithinValidatedRange;                   // true for a feed, false for a concentrate
+ec.AsTdsPpm();                               // conductivity × 0.5, the "ppm 500" convention
+
+MolarProfile molar = inTank.AsMillimolar();   // mM, which is how a feed chart is written
+NutrientRatios ratios = inTank.Ratios();      // NO₃:NH₄, K:Ca, Ca:Mg …
+```
+
+`IsWithinValidatedRange` is worth checking rather than ignoring. The EC model is validated against
+certified KCl standards up to the ionic strength of a normal feed; a concentrate at 1:100 is an order of
+magnitude past that, and outside the range the figure is an ordering rather than a measurement.
+
+## How much acid a water needs
+
+```csharp
+AcidPlan plan = AcidDose.Calculate(
+    alkalinityMilliequivalentsPerLitre: 3,
+    waterPh: 7.6,
+    targetPh: 5.8,
+    acid: Acid.Nitric60,
+    litres: 100);
+
+plan.MilliequivalentsPerLitre;   // ~2.3 — less than the alkalinity, and that is correct
+plan.Millilitres;                // what to measure out
+plan.NutrientSymbol;             // "N" — nitric acid brings nitrogen with it
+plan.NutrientPpm;                // and that nitrogen is in the reservoir
+```
+
+Worked from the carbonate equilibrium rather than a rule of thumb. Neutralising the *whole* alkalinity
+would take the water past the target pH; the usual rule overstates the dose by about a quarter.
+
+Subtract `NutrientPpm` from the target the same way you subtract the water, or the tank will carry more
+of that element than you asked for. `Acid.All` lists the six built in — nitric, phosphoric and sulfuric
+at two strengths each — and the useful trick is that the same neutralisation delivered by a different
+acid lands on a different element, so when one overshoots another usually fits.
+
+## Storing it as an A/B concentrate
+
+```csharp
+ConcentratePlan plan = recipe.AsConcentrate(concentrateLiters: 2);
+
+plan.DilutionRatio;        // 50 — a 100 L recipe in 2 L
+plan.MillilitresPerLiter;  // 20 mL of each tank per litre of water
+plan.TankA.Components;     // calcium here
+plan.TankB.Components;     // sulfates and phosphates here
+plan.MaxDilutionRatio;     // how far solubility allows you to go
+plan.Warnings;             // and whether this one will actually dissolve
+```
+
+Calcium is never stored beside sulfate or phosphate: at working strength they stay in solution, at
+concentrate strength they make gypsum and a phosphate precipitate. A single salt containing both
+internally — monocalcium phosphate — is deliberately *not* flagged, because it is a soluble compound
+rather than two reagents that happen to be adjacent.
+
+## A concentrate that will not dissolve says so, with numbers
+
+```csharp
+// 20 g of a salt that dissolves to 18 g/L, in half a litre.
+Fertilizer phosphate = new FertilizerBuilder()
+    .AddName("Calcium Monobasic Phosphate").AddType(ConcentrateType.B)
+    .AddP(23.5).AddCaNonChelated(15.9)
+    .AddWeight(20)
+    .Build();
+
+ConcentratePlan tight = new Solution([phosphate], waterLiters: 100).AsConcentrate(concentrateLiters: 0.5);
+
+ConcentrateWarning warning = tight.Warnings
+    .First(w => w.Kind == ConcentrateWarningKind.SolubilityExceeded);
+
+warning.Tank;        // ConcentrateType.B
+warning.Actual;      // 40 — g/L this salt would need
+warning.Allowed;     // 18 — g/L it dissolves to at 20 °C
+warning.Fertilizers; // which salt
+```
+
+The ordinary recipe above raises no warnings at all, which is why this example builds its own solution
+rather than reusing it — `Warnings.First(...)` on a plan that is fine throws.
+
+`Message` is prose for a log; `Actual` and `Allowed` are there so an application can write the sentence
+itself. The four kinds are a precipitation risk, a salt over its own solubility, a tank saturated by its
+salts competing for the same water, and a tank the library had to infer.
+
+Where no published solubility figure exists the plan says so in `UnknownSolubility` rather than assuming
+the salt is fine — so a ceiling computed without it may be lower than it looks.
+
+## Dependency injection
+
+```csharp
+services.AddNpkTools();   // from SYT.NPKTools.DependencyInjection
+```
+
+Registers all five services as singletons. The extension sits in the
+`Microsoft.Extensions.DependencyInjection` namespace by convention, so a typical `Program.cs` needs no
+extra `using`. This is the only reason a second package exists: `SYT.NPKTools` itself has no
+dependencies at all, which is what lets it run in a browser.
+
+## Where to read next
+
+- [README](../README.md) — the same ground at more length, with the reasoning
+- [`docs/api-reference.md`](api-reference.md) — the entry points, with signatures
+- [`docs/architecture.md`](architecture.md) — how the pieces fit
+- [`docs/faq.md`](faq.md) — when a number surprises you

--- a/tests/SYT.NPKTools.IntegrationTests/DocumentedExamplesTests.cs
+++ b/tests/SYT.NPKTools.IntegrationTests/DocumentedExamplesTests.cs
@@ -1,0 +1,253 @@
+using AwesomeAssertions;
+using SYT.NPKTools.Concentrates;
+using SYT.NPKTools.Fertilizers;
+using SYT.NPKTools.Nutrients;
+using Xunit;
+
+namespace SYT.NPKTools.IntegrationTests;
+
+/// <summary>
+/// The worked examples from <c>docs/examples.md</c>, as tests.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Documentation examples rot: an API moves, the prose stays, and a reader loses an afternoon to a
+/// snippet that has not compiled for two releases. These are the same examples the document walks
+/// through, so the build fails rather than the reader.
+/// </para>
+/// <para>
+/// They are written the way a caller would write them — factory methods, no test doubles, no internals —
+/// which is also what makes them worth reading. If one of these needs a helper to work, the API needs
+/// the helper.
+/// </para>
+/// </remarks>
+public class DocumentedExamplesTests
+{
+    /// <summary>
+    /// The shortest thing that works: a target string in, weights out.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_TheShortestThingThatWorks()
+    {
+        IPpmTargetParser parser = NpkTools.CreateTargetParser();
+        IFertilizerOptimizationService optimizer = NpkTools.CreateOptimizationService();
+
+        PpmTarget target = parser.Parse("N=150 P=50 K=210 Ca=160 Mg=50 S=65 L=100");
+        Solutions recipes = optimizer.FindMacroSolutions(target);
+
+        recipes.Should().NotBeEmpty(because: "the preset catalogue can reach an ordinary feed");
+
+        Solution recipe = recipes[0];
+        recipe.WaterLiters.Should().Be(100);
+        recipe.Should().OnlyContain(salt => salt.Weight.Value > 0);
+    }
+
+    /// <summary>
+    /// What the water already supplies comes off the target before the optimizer sees it.
+    /// </summary>
+    /// <remarks>
+    /// The number that matters here is the one that shrinks: a target of 160 ppm calcium against water
+    /// that already carries 60 leaves 100 for the salts. Every calculator that ignores this overdoses
+    /// calcium on hard water by exactly the amount the water brought.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_SourceWaterComesOffTheTarget()
+    {
+        PpmTarget target = NpkTools.CreateTargetParser().Parse("N=150 K=210 Ca=160 Mg=50 S=65 L=100");
+        WaterProfile water = new WaterProfileBuilder().AddCa(60).AddMg(12).Build();
+
+        WaterAdjustedTarget adjusted = target.AdjustFor(water);
+
+        adjusted.Target.Ca.Value.Should().BeApproximately(100, 1e-9);
+        adjusted.Target.Mg.Value.Should().BeApproximately(38, 1e-9);
+        adjusted.Excesses.Should().BeEmpty(because: "the water supplies less than the target of each");
+    }
+
+    /// <summary>
+    /// Water that oversupplies an element is reported rather than silently ignored.
+    /// </summary>
+    /// <remarks>
+    /// Fertilizer only adds. No recipe can bring calcium down once the water carries more than the
+    /// target, so the useful behaviour is to say which element and by how much.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_WaterThatOversuppliesIsReported()
+    {
+        PpmTarget target = NpkTools.CreateTargetParser().Parse("N=150 K=210 Ca=100 L=100");
+        WaterProfile hardWater = new WaterProfileBuilder().AddCa(160).Build();
+
+        WaterAdjustedTarget adjusted = target.AdjustFor(hardWater);
+
+        NutrientExcess excess = adjusted.Excesses.Should().ContainSingle().Subject;
+        excess.Element.Should().Be("Ca");
+        excess.InWater.Should().BeApproximately(160, 1e-9);
+        excess.Target.Should().BeApproximately(100, 1e-9);
+        excess.Overshoot.Should().BeApproximately(60, 1e-9);
+    }
+
+    /// <summary>
+    /// A shelf of your own salts instead of the preset catalogue.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_YourOwnShelf()
+    {
+        Fertilizer[] shelf =
+        [
+            new FertilizerBuilder().AddName("Calcium Nitrate Tetrahydrate").AddType(ConcentrateType.A)
+                .AddNo3(11.86).AddCaNonChelated(16.97).Build(),
+            new FertilizerBuilder().AddName("Potassium Nitrate").AddType(ConcentrateType.A)
+                .AddNo3(13.85).AddK(38.67).Build(),
+            new FertilizerBuilder().AddName("Magnesium Sulfate Heptahydrate").AddType(ConcentrateType.B)
+                .AddMgNonChelated(9.86).AddS(13.01).Build(),
+            new FertilizerBuilder().AddName("Monopotassium Phosphate").AddType(ConcentrateType.B)
+                .AddP(22.76).AddK(28.73).Build(),
+            new FertilizerBuilder().AddName("Potassium Sulfate").AddType(ConcentrateType.B)
+                .AddK(44.87).AddS(18.4).Build(),
+            new FertilizerBuilder().AddName("Ammonium Nitrate").AddType(ConcentrateType.A)
+                .AddNo3(17.5).AddNh4(17.5).Build(),
+        ];
+
+        IFertilizerOptimizationService optimizer = NpkTools.CreateOptimizationService(shelf);
+        PpmTarget target = NpkTools.CreateTargetParser().Parse("N=150 P=50 K=210 Ca=160 Mg=50 S=65 L=100");
+
+        Solutions recipes = optimizer.FindMacroSolutions(target);
+
+        recipes.Should().NotBeEmpty();
+        recipes[0].Select(salt => salt.Name.Value).Should().BeSubsetOf(shelf.Select(s => s.Name.Value));
+    }
+
+    /// <summary>
+    /// A salt described by its chemical formula, with the percentages derived rather than typed.
+    /// </summary>
+    /// <remarks>
+    /// This is the safe way in, and the reason is the oxide convention: a bag quotes P₂O₅ and K₂O, and a
+    /// figure copied straight off it overstates phosphorus by 2.29×. A formula cannot make that mistake.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_ASaltFromItsFormula()
+    {
+        ChemicalFormula.TryParse("KNO3", out ChemicalFormula? formula, out FormulaProblem? problem)
+            .Should().BeTrue(because: problem?.Message);
+
+        formula!.MolarMass.Should().BeApproximately(101.1, 0.1);
+        formula.PercentOf("K").Should().BeApproximately(38.67, 0.05);
+        formula.NitratePercent.Should().BeApproximately(13.85, 0.05);
+
+        FormulaComposition.TryCreate("Shop KNO3", "KNO3", ConcentrateType.A, out Fertilizer? salt, out _)
+            .Should().BeTrue();
+        salt!.Name.Value.Should().Be("Shop KNO3");
+    }
+
+    /// <summary>
+    /// A formula that cannot be read says which failure it is, not just that it failed.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_AFormulaThatCannotBeRead()
+    {
+        ChemicalFormula.TryParse("KNO3!", out _, out FormulaProblem? problem).Should().BeFalse();
+
+        problem!.Kind.Should().Be(FormulaProblemKind.UnexpectedCharacter);
+        problem.Value.Should().Be("!");
+        problem.Position.Should().Be(5);
+    }
+
+    /// <summary>
+    /// Judging a recipe rather than only computing it: what is actually in the tank, and what a meter
+    /// will say about it.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_JudgeTheMix()
+    {
+        PpmTarget target = NpkTools.CreateTargetParser().Parse("N=150 P=50 K=210 Ca=160 Mg=50 S=65 L=100");
+        Solution recipe = NpkTools.CreateOptimizationService().FindMacroSolutions(target)[0];
+
+        Ppm inTank = NpkTools.CreatePpmCalculator().CalculatePpm(recipe, recipe.WaterLiters);
+
+        inTank.Nitrogen.Value.Should().BeApproximately(150, 1.5, because: "within 1%, which is finer than a kitchen scale");
+
+        ConductivityEstimate ec = inTank.EstimateConductivity();
+        ec.MilliSiemensPerCm.Should().BeInRange(1.0, 3.0);
+        ec.IsWithinValidatedRange.Should().BeTrue(because: "an ordinary feed is inside the range the model was checked against");
+
+        // A TDS meter is a conductivity meter with a multiplier chosen by its manufacturer.
+        ec.AsTdsPpm().Should().BeApproximately(ec.MicroSiemensPerCm * 0.5, 1);
+    }
+
+    /// <summary>
+    /// The acid a water's alkalinity needs, from the carbonate equilibrium rather than a rule of thumb.
+    /// </summary>
+    /// <remarks>
+    /// The figure worth noticing is that the dose is less than the alkalinity. Neutralising all of it
+    /// would take the water past the target pH; the rule of thumb overstates the dose by about a quarter.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_HowMuchAcid()
+    {
+        AcidPlan plan = AcidDose.Calculate(
+            alkalinityMilliequivalentsPerLitre: 3,
+            waterPh: 7.6,
+            targetPh: 5.8,
+            acid: Acid.Nitric60,
+            litres: 100);
+
+        plan.MilliequivalentsPerLitre.Should().BeLessThan(3);
+        plan.MilliequivalentsPerLitre.Should().BeApproximately(2.3, 0.1);
+        plan.Millilitres.Should().BePositive();
+
+        // Nitric acid brings nitrogen with it, and that nitrogen is in the reservoir.
+        plan.NutrientSymbol.Should().Be("N");
+        plan.NutrientPpm.Should().BePositive();
+    }
+
+    /// <summary>
+    /// A recipe stored as an A/B concentrate, checked for whether it will physically dissolve.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_AsAConcentrate()
+    {
+        PpmTarget target = NpkTools.CreateTargetParser().Parse("N=150 P=50 K=210 Ca=160 Mg=50 S=65 L=100");
+        Solution recipe = NpkTools.CreateOptimizationService().FindMacroSolutions(target)[0];
+
+        ConcentratePlan plan = recipe.AsConcentrate(concentrateLiters: 2);
+
+        plan.DilutionRatio.Should().BeApproximately(50, 1e-9);
+        plan.TankA.Components.Should().NotBeEmpty();
+        plan.TankB.Components.Should().NotBeEmpty();
+
+        // Calcium is never stored beside sulfate or phosphate: at concentrate strength they precipitate.
+        plan.TankA.Components.Should().OnlyContain(c => c.Fertilizer.Type == ConcentrateType.A);
+        plan.TankB.Components.Should().OnlyContain(c => c.Fertilizer.Type == ConcentrateType.B);
+    }
+
+    /// <summary>
+    /// A concentrate too strong to dissolve says so, with the two figures behind the sentence.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Example_AConcentrateThatWillNotDissolve()
+    {
+        Fertilizer phosphate = new FertilizerBuilder()
+            .AddName("Calcium Monobasic Phosphate")
+            .AddType(ConcentrateType.B)
+            .AddP(23.5).AddCaNonChelated(15.9)
+            .AddWeight(20)
+            .Build();
+
+        ConcentratePlan plan = new Solution([phosphate], waterLiters: 100).AsConcentrate(concentrateLiters: 0.5);
+
+        ConcentrateWarning warning = plan.Warnings
+            .Should().ContainSingle(w => w.Kind == ConcentrateWarningKind.SolubilityExceeded).Subject;
+
+        warning.Actual.Should().BeApproximately(40, 1e-9, because: "20 g in 0.5 L is 40 g/L");
+        warning.Allowed.Should().Be(18, because: "that is what the table gives at 20 °C");
+    }
+}


### PR DESCRIPTION
Closes the last part of #2.

## The examples are tests

`docs/examples.md` walks through ten scenarios, and every one is a test in [`DocumentedExamplesTests`](../../tests/SYT.NPKTools.IntegrationTests/DocumentedExamplesTests.cs) — the same code, run in CI.

```bash
dotnet test tests/SYT.NPKTools.IntegrationTests --filter "FullyQualifiedName~DocumentedExamples"
```

Documentation examples rot: an API moves, the prose stays, and a reader loses an afternoon to a snippet that has not compiled for two releases. Here the build fails instead of the reader.

**That paid for itself immediately.** The "your own shelf" example did not work with the four salts I first wrote, for the reason the previous review turned up: every element the target *names* is solved as an exact equality, so four salts whose elements are pairwise tied are over-constrained rather than short of an ingredient. A reviewer then measured the threshold — **four solve nothing, five give one recipe, six give two** — so the document teaches that instead of asserting a round number.

## The reference gives the shape, not a dump

`docs/api-reference.md` covers which of the public types you actually touch, in what order, and which you can substitute. The XML documentation ships in the package and stays the authority. Signatures were extracted from source with a script rather than typed from memory.

**A reviewer still found twelve things wrong.** The worst was in the examples, not the reference:

> a snippet reused `plan` from the section above it to show a solubility warning — and that plan has no warnings, so anyone copying it would have got an exception from `.First()`

The rest, corrected:

| Claimed | Actually |
|---|---|
| six of seven interfaces substitutable via `NpkTools` | **one** — `IOptimizationProblemSolver`; the mapper, repository and optimizer are constructed internally |
| all seven in two namespaces | three — `IPpmTargetParser` and `IPpmCalculationService` are in `.Nutrients` |
| "loosen `RangeFactor`" | loosening means **lowering** it; 1 is the tightest and above 1 is rejected |
| a zero target element is unconstrained | an element the target never mentions is; one you set to `0` is pinned to `0` |
| `Ppm` has three extension methods | six — also `IonBalance()`, `Plus`, `Breakdown` |
| `EstimateConductivity` plus "an overload taking alkalinity" | one method, `bicarbonateMeqPerLitre = 0` — and leaving it at zero understates the EC of anything mixed into real water |
| four parameter names | `cancellationToken`, `sourceCollection`, `solutionValues`, `originalSourceCollection`, `symbol` |
| "every public member carries a `<summary>`" | `.editorconfig` exempts `ValueObjects/`, `Builders/`, `Internal/` — so every `FertilizerBuilder.Add…` is undocumented by design, which is exactly what a reader looks up and does not find |

Also filled in members whose absence misled: `ConcentratePlan.ConcentrateLiters`/`WorkingLiters`, `IonBalance.AcidEquivalents`/`IsChargeNeutral`, `WaterEstimate.RelativeError` (and that its constructor is internal), `WaterEstimator.Estimate`'s signature, `ConcentrateComponent`'s members, `Acid`'s full set, `ChemicalFormula.Atoms`, and that `Feasible` is false in both directions rather than only on conflicting hardness.

## Also

`README.md` gains a documentation line near the top, and `docs/architecture.md` picks up the same two `RangeFactor` corrections.

830 tests pass.

## #2, complete

| Asked for | Where |
|---|---|
| install, configure, use | [README](../../README.md) + [examples](../../docs/examples.md) |
| API descriptions | [api-reference.md](../../docs/api-reference.md), with the XML docs as the authority |
| practical examples | [examples.md](../../docs/examples.md) — ten, all tests |
| contributor information | [CONTRIBUTING.md](../../CONTRIBUTING.md) + [scripts/](../../scripts/README.md) |
| architecture and workflow diagrams | [architecture.md](../../docs/architecture.md), four mermaid diagrams |
| FAQ and troubleshooting | [faq.md](../../docs/faq.md) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNUy8YNDR2iVsg2aN9oam